### PR TITLE
Always upload screenshots of errors

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,6 +50,7 @@ jobs:
           browser: ${{ matrix.browser }}
           start: 'yarn build:serve'
       - uses: actions/upload-artifact@master
+        if: always()
         with:
           name: screenshots
           path: cypress/screenshots


### PR DESCRIPTION
### Component/Part
CI

### Description
When the pipeline is cancelled by a preceding failing job, the screenshot upload job won't run. This change adds the flag that it will run even when preceding jobs failed.

### Steps

<!-- please tick steps this PR performs (if something is not necessary, please tick anyway to indicate you considered it) -->

- [ ] added implementation
- [ ] added / updated tests
- [ ] added / updated documentation
- [ ] extended changelog

### Related Issue(s)
none
