### PR TITLE
added gitSignOff preset to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":gitSignOff"
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
this adds Signed-off to the commit messages of renovate (see https://docs.renovatebot.com/presets-default/#gitsignoff)

Signed-off-by: Philip Molares <philip.molares@udo.edu>