### PR TITLE
Use safer node_modules cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,17 +20,23 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Cache node_modules
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v2
+        id: yarn-cache
         with:
-          path: node_modules
-          key: node_modules
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Set up NodeJS
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile --prefer-offline
       - name: Test Project
         run: yarn test
       - name: Build project

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,20 +16,32 @@ jobs:
     name: build frontend
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
       - name: Cache build
         uses: actions/cache@v2.1.3
         with:
           path: build
           key: build
+
       - name: Cache node_modules
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v2
+        id: yarn-cache
         with:
-          path: node_modules
-          key: node_modules
-      - uses: actions/setup-node@v1
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Set up NodeJS
+        uses: actions/setup-node@v1
         with:
-          node-version: '14'
-      - run: yarn install
+          node-version: 14
+
+      - run: yarn install --frozen-lockfile --prefer-offline
       - run: yarn build
       - uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,16 +17,25 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
       - name: Cache node_modules
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v2
+        id: yarn-cache
         with:
-          path: node_modules
-          key: node_modules
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Set up NodeJS
         uses: actions/setup-node@v1
         with:
           node-version: 14
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile --prefer-offline
       - name: Lint code
         run: yarn lint


### PR DESCRIPTION
### Component/Part
CI

### Description
This PR improves the caching of node_modules in the CI by binding the cache to the yarn.lock

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
Closes #760