### PR TITLE
Fixed branding icon path in mocked cypress config

### DIFF
--- a/cypress/support/config.ts
+++ b/cypress/support/config.ts
@@ -11,7 +11,7 @@ export const banner = {
 
 export const branding = {
   name: 'ACME Corp',
-  logo: 'http://localhost:3001/acme.png'
+  logo: 'http://localhost:3001/img/acme.png'
 }
 
 beforeEach(() => {


### PR DESCRIPTION
### Component/Part
cypress tests

### Description
This PR fixes the path of the branding icon during cypress test runs.

### Steps
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
none
