### PR TITLE
Extract windows location code into hook

### DIFF
--- a/src/components/application-loader/application-loader.tsx
+++ b/src/components/application-loader/application-loader.tsx
@@ -5,18 +5,17 @@ SPDX-License-Identifier: AGPL-3.0-only
 */
 
 import React, { Suspense, useCallback, useEffect, useState } from 'react'
-import { useLocation } from 'react-router'
+import { useFrontendBaseUrl } from '../../hooks/common/use-frontend-base-url'
 import './application-loader.scss'
 import { createSetUpTaskList, InitTask } from './initializers'
 import { LoadingScreen } from './loading-screen'
 
 export const ApplicationLoader: React.FC = ({ children }) => {
-  const { pathname } = useLocation()
+  const frontendUrl = useFrontendBaseUrl()
 
   const setUpTasks = useCallback(() => {
-    const baseUrl: string = window.location.pathname.replace(pathname, '')
-    return createSetUpTaskList(baseUrl)
-  }, [pathname])
+    return createSetUpTaskList(frontendUrl)
+  }, [frontendUrl])
 
   const [failedTitle, setFailedTitle] = useState<string>('')
   const [doneTasks, setDoneTasks] = useState<number>(0)

--- a/src/hooks/common/use-frontend-base-url.ts
+++ b/src/hooks/common/use-frontend-base-url.ts
@@ -1,0 +1,7 @@
+import { useLocation } from 'react-router'
+
+export const useFrontendBaseUrl = (): string => {
+  const { pathname } = useLocation()
+
+  return window.location.pathname.replace(pathname, '')
+}

--- a/src/hooks/common/use-frontend-base-url.ts
+++ b/src/hooks/common/use-frontend-base-url.ts
@@ -1,3 +1,9 @@
+/*
+SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
 import { useLocation } from 'react-router'
 
 export const useFrontendBaseUrl = (): string => {


### PR DESCRIPTION
### Component/Part
Application Loader / Common hooks

### Description
This PR extracts the code for finding the frontend base url into a hook.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
