### PR TITLE
Change renovate label to "type: maintenance"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     ":gitSignOff"
   ],
   "labels": [
-    "dependencies"
+    "type: maintenance"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
### Component/Part
renovate config

### Description
This PR changes the label that renovate uses to "type: maintenance"

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
