### PR TITLE
removed the f9 shortcut to sort all lines in a pad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 - Alternative anchor URL formats
 - Import HTML and convert to Markdown
 - Import content from a url
+- F9 shortcut to sort lines
 
 ### Added
 

--- a/src/components/editor/editor-pane/key-map.ts
+++ b/src/components/editor/editor-pane/key-map.ts
@@ -16,6 +16,7 @@ import {
 
 const isVim = (keyMapName?: string) => (keyMapName?.substr(0, 3) === 'vim')
 
+const pass = (_: Editor): void | typeof Pass => undefined
 const f10 = (editor: Editor): void | typeof Pass => editor.setOption('fullScreen', !editor.getOption('fullScreen'))
 const esc = (editor: Editor): void | typeof Pass => {
   if (editor.getOption('fullScreen') && !isVim(editor.getOption('keyMap'))) {
@@ -69,6 +70,7 @@ const tab = (editor: Editor) => {
 
 export const defaultKeyMap: KeyMap = !isMac
   ? {
+      F9: pass,
       F10: f10,
       Esc: esc,
       'Ctrl-S': suppressSave,
@@ -83,6 +85,7 @@ export const defaultKeyMap: KeyMap = !isMac
       'Ctrl-M': markSelection
     }
   : {
+      F9: pass,
       F10: f10,
       Esc: esc,
       'Cmd-S': suppressSave,

--- a/src/components/editor/editor-pane/key-map.ts
+++ b/src/components/editor/editor-pane/key-map.ts
@@ -16,7 +16,6 @@ import {
 
 const isVim = (keyMapName?: string) => (keyMapName?.substr(0, 3) === 'vim')
 
-const pass = (_: Editor): void | typeof Pass => undefined
 const f10 = (editor: Editor): void | typeof Pass => editor.setOption('fullScreen', !editor.getOption('fullScreen'))
 const esc = (editor: Editor): void | typeof Pass => {
   if (editor.getOption('fullScreen') && !isVim(editor.getOption('keyMap'))) {
@@ -25,7 +24,7 @@ const esc = (editor: Editor): void | typeof Pass => {
     return CodeMirror.Pass
   }
 }
-const suppressSave = (): undefined => undefined
+const suppressKey = (): undefined => undefined
 const tab = (editor: Editor) => {
   const tab = '\t'
 
@@ -70,10 +69,10 @@ const tab = (editor: Editor) => {
 
 export const defaultKeyMap: KeyMap = !isMac
   ? {
-      F9: pass,
+      F9: suppressKey,
       F10: f10,
       Esc: esc,
-      'Ctrl-S': suppressSave,
+      'Ctrl-S': suppressKey,
       Enter: 'newlineAndIndentContinueMarkdownList',
       Tab: tab,
       Home: 'goLineLeftSmart',
@@ -85,10 +84,10 @@ export const defaultKeyMap: KeyMap = !isMac
       'Ctrl-M': markSelection
     }
   : {
-      F9: pass,
+      F9: suppressKey,
       F10: f10,
       Esc: esc,
-      'Cmd-S': suppressSave,
+      'Cmd-S': suppressKey,
       Enter: 'newlineAndIndentContinueMarkdownList',
       Tab: tab,
       'Cmd-Left': 'goLineLeftSmart',


### PR DESCRIPTION
### Component/Part
editor

### Description
This PR removes the f9 shortcut to sort all lines in a pad

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Extended changelog
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
fixes #813 