### PR TITLE
Add new package group for markmap

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,13 @@
       "automerge": true
     },
     {
+      "groupName": "markmap",
+      "packagePatterns": [
+        "markmap-view",
+        "markmap-lib"
+      ]
+    },
+    {
       "groupName": "JS test packages",
       "packagePatterns": [
         "^@testing-library/"


### PR DESCRIPTION
### Component/Part
Renovate

### Description
`markmap-view` and `markmap-lib` should be updated at once. This PR adds a new package group for renovate.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
#831 #830