### PR TITLE
Change tsconfig for jsx transpiler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
         "resolveJsonModule": true,
         "isolatedModules": true,
         "noEmit": true,
-        "jsx": "react"
+        "jsx": "react-jsx"
     },
     "include": [
         "src"


### PR DESCRIPTION
### Component/Part
tsconfig

### Description

The current tsconfig gets adjusted by craco every time you run it with outdated settings.
`  - compilerOptions.jsx must be react-jsx (to support the new JSX transform in React 17)`

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
