### PR TITLE
Add jetbrains copyright autocomplection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,8 @@
 # ide
 .idea
 !.idea/dictionaries/hedgedoc.xml
-
+!.idea/copyright/*
+!.idea/jsLinters/*
 # misc
 .DS_Store
 .env.local

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@
 # ide
 .idea
 !.idea/dictionaries/hedgedoc.xml
-!.idea/copyright/*
-!.idea/jsLinters/*
+!.idea/copyright
+!.idea/jsLinters
 # misc
 .DS_Store
 .env.local

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@
 .idea
 !.idea/dictionaries/hedgedoc.xml
 !.idea/copyright
-!.idea/jsLinters
 # misc
 .DS_Store
 .env.local

--- a/.idea/copyright/hedgedoc.xml
+++ b/.idea/copyright/hedgedoc.xml
@@ -1,6 +1,6 @@
 <component name="CopyrightManager">
   <copyright>
-    <option name="notice" value="SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)&#10;&#10;SPDX-License-Identifier: AGPL-3.0-only" />
+    <option name="notice" value="SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)&#10;&#10;&#83;PDX-License-Identifier: AGPL-3.0-only" />
     <option name="myName" value="hedgedoc" />
   </copyright>
 </component>

--- a/.idea/copyright/hedgedoc.xml
+++ b/.idea/copyright/hedgedoc.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)&#10;&#10;SPDX-License-Identifier: AGPL-3.0-only" />
+    <option name="myName" value="hedgedoc" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <settings default="hedgedoc">
+    <module2copyright>
+      <element module="All" copyright="hedgedoc" />
+    </module2copyright>
+  </settings>
+</component>

--- a/.idea/jsLinters/eslint.xml
+++ b/.idea/jsLinters/eslint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EslintConfiguration">
+    <option name="fix-on-save" value="true" />
+  </component>
+</project>

--- a/.idea/jsLinters/eslint.xml
+++ b/.idea/jsLinters/eslint.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="EslintConfiguration">
-    <option name="fix-on-save" value="true" />
-  </component>
-</project>

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -31,6 +31,10 @@ Files: public/robots.txt
 Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
+Files: .idea/**
+Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+License: CC0-1.0
+
 Files: .github/ISSUE_TEMPLATE/*.md
 Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
 License: CC-BY-SA-4.0


### PR DESCRIPTION
### Component/Part
Jetbrains IDE settings

### Description
The core developers use webstorm, which has a handy method to add a copyright header to new files. This PR activates this feature.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

