### PR TITLE
Fix bug that pathname is always empty

### DIFF
--- a/src/hooks/common/use-frontend-base-url.ts
+++ b/src/hooks/common/use-frontend-base-url.ts
@@ -9,5 +9,5 @@ import { useLocation } from 'react-router'
 export const useFrontendBaseUrl = (): string => {
   const { pathname } = useLocation()
 
-  return window.location.pathname.replace(pathname, '')
+  return window.location.href.replace(pathname, '')
 }

--- a/src/hooks/common/use-frontend-base-url.ts
+++ b/src/hooks/common/use-frontend-base-url.ts
@@ -8,8 +8,8 @@ import { useLocation } from 'react-router'
 
 export const useFrontendBaseUrl = (): string => {
   const { pathname } = useLocation()
-  const loc = window.location
-  const cleanedPathName = loc.pathname.replace(pathname, '')
+  const location = window.location
+  const cleanedPathName = location.pathname.replace(pathname, '')
 
-  return `${loc.protocol}//${loc.host}${cleanedPathName}`
+  return `${location.protocol}//${location.host}${cleanedPathName}`
 }

--- a/src/hooks/common/use-frontend-base-url.ts
+++ b/src/hooks/common/use-frontend-base-url.ts
@@ -8,6 +8,8 @@ import { useLocation } from 'react-router'
 
 export const useFrontendBaseUrl = (): string => {
   const { pathname } = useLocation()
+  const loc = window.location
+  const cleanedPathName = loc.pathname.replace(pathname, '')
 
-  return window.location.href.replace(pathname, '')
+  return `${loc.protocol}//${loc.host}${cleanedPathName}`
 }


### PR DESCRIPTION
### Component/Part
Helpers -> base Url hook

### Description
This PR fixes the base url hook  that always returned an empty string because from the pathname the pathname was eliminated. It should be that from the full URL the pathname gets removed.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

