### PR TITLE
Enhance share dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 - Markdown files can be imported into an existing note directly from the editor.
 - The table button in the toolbar opens an overlay where the user can choose the number of columns and rows
 - A toggle in the editor preferences for turning ligatures on and off.
+- Easier possibility to share notes via native share-buttons on supported devices.
 
 ### Changed
 

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -389,7 +389,9 @@
             },
             "shareLink": {
                 "title": "Share link",
-                "viewOnlyDescription": "This link points to a read-only version of this note. You can use this e.g. for feedback from friends and colleagues."
+                "editorDescription": "This link points to this note in the editor as you currently see it.",
+                "viewOnlyDescription": "This link points to a read-only version of this note. You can use this e.g. for feedback from friends and colleagues.",
+                "slidesDescription": "This link points to the presentation view of the slides."
             },
             "preferences": {
                 "title": "Preferences",

--- a/src/components/common/copyable/copyable-field/copyable-field.tsx
+++ b/src/components/common/copyable/copyable-field/copyable-field.tsx
@@ -4,31 +4,52 @@ SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
 SPDX-License-Identifier: AGPL-3.0-only
 */
 
-import React, { Fragment, useRef } from 'react'
+import React, { Fragment, useCallback, useRef } from 'react'
 import { Button, FormControl, InputGroup } from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import { ForkAwesomeIcon } from '../../fork-awesome/fork-awesome-icon'
+import { ShowIf } from '../../show-if/show-if'
 import { CopyOverlay } from '../copy-overlay'
 
 export interface CopyableFieldProps {
   content: string
+  nativeShareButton?: boolean
+  url?: string
 }
 
-export const CopyableField: React.FC<CopyableFieldProps> = ({ content }) => {
+export const CopyableField: React.FC<CopyableFieldProps> = ({ content, nativeShareButton, url }) => {
   useTranslation()
-  const button = useRef<HTMLButtonElement>(null)
+  const copyButton = useRef<HTMLButtonElement>(null)
+
+  const doShareAction = useCallback(() => {
+    navigator.share({
+      text: content,
+      url: url
+    }).catch(err => {
+      console.error('Native sharing failed: ', err)
+    })
+  }, [content, url])
+
+  const sharingSupported = typeof navigator.share === 'function'
 
   return (
     <Fragment>
       <InputGroup className="my-3">
         <FormControl readOnly={true} className={'text-center'} value={content} />
         <InputGroup.Append>
-          <Button variant="outline-secondary" ref={button} title={'Copy'}>
+          <Button variant="outline-secondary" ref={copyButton} title={'Copy'}>
             <ForkAwesomeIcon icon='files-o'/>
           </Button>
         </InputGroup.Append>
+        <ShowIf condition={!!nativeShareButton && sharingSupported}>
+          <InputGroup.Append>
+            <Button variant="outline-secondary" title={'Share'} onClick={doShareAction}>
+              <ForkAwesomeIcon icon='share-alt'/>
+            </Button>
+          </InputGroup.Append>
+        </ShowIf>
       </InputGroup>
-      <CopyOverlay content={content} clickComponent={button}/>
+      <CopyOverlay content={content} clickComponent={copyButton}/>
     </Fragment>
   )
 }

--- a/src/components/editor/app-bar/editor-view-mode.tsx
+++ b/src/components/editor/app-bar/editor-view-mode.tsx
@@ -13,9 +13,9 @@ import { setEditorMode } from '../../../redux/editor/methods'
 import { ForkAwesomeIcon } from '../../common/fork-awesome/fork-awesome-icon'
 
 export enum EditorMode {
-  PREVIEW,
-  BOTH,
-  EDITOR,
+  PREVIEW = 'view',
+  BOTH = 'both',
+  EDITOR = 'edit',
 }
 
 export const EditorViewMode: React.FC = () => {

--- a/src/components/editor/document-bar/buttons/share-link-button.tsx
+++ b/src/components/editor/document-bar/buttons/share-link-button.tsx
@@ -4,17 +4,21 @@ SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
 SPDX-License-Identifier: AGPL-3.0-only
 */
 
-import React, { Fragment, useCallback, useState } from 'react'
+import equal from 'fast-deep-equal'
+import React, { Fragment, useState } from 'react'
 import { Modal } from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
+import { ApplicationState } from '../../../../redux'
 import { CopyableField } from '../../../common/copyable/copyable-field/copyable-field'
 import { TranslatedIconButton } from '../../../common/icon-button/translated-icon-button'
 import { CommonModal } from '../../../common/modals/common-modal'
 import { ShowIf } from '../../../common/show-if/show-if'
 
 export const ShareLinkButton: React.FC = () => {
-  const { t } = useTranslation()
+  useTranslation()
   const [showShareDialog, setShowShareDialog] = useState(false)
+  const noteMetadata = useSelector((state: ApplicationState) => state.documentContent.metadata, equal)
 
   return (
     <Fragment>
@@ -23,7 +27,8 @@ export const ShareLinkButton: React.FC = () => {
         className={'mx-1'}
         icon={'share'}
         variant={'light'}
-        onClick={() => setShowShareDialog(true)} i18nKey={'editor.documentBar.shareLink'}
+        onClick={() => setShowShareDialog(true)}
+        i18nKey={'editor.documentBar.shareLink'}
       />
       <CommonModal
         show={showShareDialog}
@@ -33,11 +38,11 @@ export const ShareLinkButton: React.FC = () => {
         <Modal.Body>
           <Trans i18nKey={'editor.modal.shareLink.editorDescription'}/>
           <CopyableField content={'edit link'}/>
-          <ShowIf condition={true}>
+          <ShowIf condition={noteMetadata.type === 'slide'}>
             <Trans i18nKey={'editor.modal.shareLink.slidesDescription'}/>
             <CopyableField content={'slides link'}/>
           </ShowIf>
-          <ShowIf condition={true}>
+          <ShowIf condition={noteMetadata.type === ''}>
             <Trans i18nKey={'editor.modal.shareLink.viewOnlyDescription'}/>
             <CopyableField content={'view link'}/>
           </ShowIf>

--- a/src/components/editor/document-bar/buttons/share-link-button.tsx
+++ b/src/components/editor/document-bar/buttons/share-link-button.tsx
@@ -22,6 +22,7 @@ export const ShareLinkButton: React.FC = () => {
   useTranslation()
   const [showShareDialog, setShowShareDialog] = useState(false)
   const noteMetadata = useSelector((state: ApplicationState) => state.documentContent.metadata, equal)
+  const editorMode = useSelector((state: ApplicationState) => state.editorConfig.editorMode)
   const baseUrl = useFrontendBaseUrl()
   const { id } = useParams<EditorPathParams>()
 
@@ -42,7 +43,7 @@ export const ShareLinkButton: React.FC = () => {
         titleI18nKey={'editor.modal.shareLink.title'}>
         <Modal.Body>
           <Trans i18nKey={'editor.modal.shareLink.editorDescription'}/>
-          <CopyableField content={`${baseUrl}/n/${id}`} nativeShareButton={true} url={`${baseUrl}/n/${id}`}/>
+          <CopyableField content={`${baseUrl}/n/${id}?${editorMode}`} nativeShareButton={true} url={`${baseUrl}/n/${id}?${editorMode}`}/>
           <ShowIf condition={noteMetadata.type === 'slide'}>
             <Trans i18nKey={'editor.modal.shareLink.slidesDescription'}/>
             <CopyableField content={`${baseUrl}/p/${id}`} nativeShareButton={true} url={`${baseUrl}/p/${id}`}/>

--- a/src/components/editor/document-bar/buttons/share-link-button.tsx
+++ b/src/components/editor/document-bar/buttons/share-link-button.tsx
@@ -9,16 +9,21 @@ import React, { Fragment, useState } from 'react'
 import { Modal } from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
+import { useParams } from 'react-router-dom'
+import { useFrontendBaseUrl } from '../../../../hooks/common/use-frontend-base-url'
 import { ApplicationState } from '../../../../redux'
 import { CopyableField } from '../../../common/copyable/copyable-field/copyable-field'
 import { TranslatedIconButton } from '../../../common/icon-button/translated-icon-button'
 import { CommonModal } from '../../../common/modals/common-modal'
 import { ShowIf } from '../../../common/show-if/show-if'
+import { EditorPathParams } from '../../editor'
 
 export const ShareLinkButton: React.FC = () => {
   useTranslation()
   const [showShareDialog, setShowShareDialog] = useState(false)
   const noteMetadata = useSelector((state: ApplicationState) => state.documentContent.metadata, equal)
+  const baseUrl = useFrontendBaseUrl()
+  const { id } = useParams<EditorPathParams>()
 
   return (
     <Fragment>
@@ -37,14 +42,14 @@ export const ShareLinkButton: React.FC = () => {
         titleI18nKey={'editor.modal.shareLink.title'}>
         <Modal.Body>
           <Trans i18nKey={'editor.modal.shareLink.editorDescription'}/>
-          <CopyableField content={'edit link'} nativeShareButton={true} url={''}/>
+          <CopyableField content={`${baseUrl}/n/${id}`} nativeShareButton={true} url={`${baseUrl}/n/${id}`}/>
           <ShowIf condition={noteMetadata.type === 'slide'}>
             <Trans i18nKey={'editor.modal.shareLink.slidesDescription'}/>
-            <CopyableField content={'slides link'} nativeShareButton={true} url={''}/>
+            <CopyableField content={`${baseUrl}/p/${id}`} nativeShareButton={true} url={`${baseUrl}/p/${id}`}/>
           </ShowIf>
           <ShowIf condition={noteMetadata.type === ''}>
             <Trans i18nKey={'editor.modal.shareLink.viewOnlyDescription'}/>
-            <CopyableField content={'view link'} nativeShareButton={true} url={''}/>
+            <CopyableField content={`${baseUrl}/s/${id}`} nativeShareButton={true} url={`${baseUrl}/s/${id}`}/>
           </ShowIf>
         </Modal.Body>
       </CommonModal>

--- a/src/components/editor/document-bar/buttons/share-link-button.tsx
+++ b/src/components/editor/document-bar/buttons/share-link-button.tsx
@@ -37,14 +37,14 @@ export const ShareLinkButton: React.FC = () => {
         titleI18nKey={'editor.modal.shareLink.title'}>
         <Modal.Body>
           <Trans i18nKey={'editor.modal.shareLink.editorDescription'}/>
-          <CopyableField content={'edit link'}/>
+          <CopyableField content={'edit link'} nativeShareButton={true} url={''}/>
           <ShowIf condition={noteMetadata.type === 'slide'}>
             <Trans i18nKey={'editor.modal.shareLink.slidesDescription'}/>
-            <CopyableField content={'slides link'}/>
+            <CopyableField content={'slides link'} nativeShareButton={true} url={''}/>
           </ShowIf>
           <ShowIf condition={noteMetadata.type === ''}>
             <Trans i18nKey={'editor.modal.shareLink.viewOnlyDescription'}/>
-            <CopyableField content={'view link'}/>
+            <CopyableField content={'view link'} nativeShareButton={true} url={''}/>
           </ShowIf>
         </Modal.Body>
       </CommonModal>

--- a/src/components/editor/document-bar/buttons/share-link-button.tsx
+++ b/src/components/editor/document-bar/buttons/share-link-button.tsx
@@ -4,27 +4,43 @@ SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
 SPDX-License-Identifier: AGPL-3.0-only
 */
 
-import React, { Fragment, useState } from 'react'
+import React, { Fragment, useCallback, useState } from 'react'
 import { Modal } from 'react-bootstrap'
-import { Trans } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { CopyableField } from '../../../common/copyable/copyable-field/copyable-field'
 import { TranslatedIconButton } from '../../../common/icon-button/translated-icon-button'
 import { CommonModal } from '../../../common/modals/common-modal'
+import { ShowIf } from '../../../common/show-if/show-if'
 
 export const ShareLinkButton: React.FC = () => {
-  const [showReadOnly, setShowReadOnly] = useState(false)
+  const { t } = useTranslation()
+  const [showShareDialog, setShowShareDialog] = useState(false)
 
   return (
     <Fragment>
-      <TranslatedIconButton size={'sm'} className={'mx-1'} icon={'share'} variant={'light'} onClick={() => setShowReadOnly(true)} i18nKey={'editor.documentBar.shareLink'}/>
+      <TranslatedIconButton
+        size={'sm'}
+        className={'mx-1'}
+        icon={'share'}
+        variant={'light'}
+        onClick={() => setShowShareDialog(true)} i18nKey={'editor.documentBar.shareLink'}
+      />
       <CommonModal
-        show={showReadOnly}
-        onHide={() => setShowReadOnly(false)}
+        show={showShareDialog}
+        onHide={() => setShowShareDialog(false)}
         closeButton={true}
         titleI18nKey={'editor.modal.shareLink.title'}>
         <Modal.Body>
-          <span className={'my-4'}><Trans i18nKey={'editor.modal.shareLink.viewOnlyDescription'}/></span>
-          <CopyableField content={'https://example.com'}/>
+          <Trans i18nKey={'editor.modal.shareLink.editorDescription'}/>
+          <CopyableField content={'edit link'}/>
+          <ShowIf condition={true}>
+            <Trans i18nKey={'editor.modal.shareLink.slidesDescription'}/>
+            <CopyableField content={'slides link'}/>
+          </ShowIf>
+          <ShowIf condition={true}>
+            <Trans i18nKey={'editor.modal.shareLink.viewOnlyDescription'}/>
+            <CopyableField content={'view link'}/>
+          </ShowIf>
         </Modal.Body>
       </CommonModal>
     </Fragment>

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -12,7 +12,7 @@ import useMedia from 'use-media'
 import { useApplyDarkMode } from '../../hooks/common/use-apply-dark-mode'
 import { useDocumentTitle } from '../../hooks/common/use-document-title'
 import { ApplicationState } from '../../redux'
-import { setDocumentContent, setNoteId } from '../../redux/document-content/methods'
+import { setDocumentContent, setDocumentMetadata, setNoteId } from '../../redux/document-content/methods'
 import { setEditorMode } from '../../redux/editor/methods'
 import { extractNoteTitle } from '../common/document-title/note-title-extractor'
 import { MotdBanner } from '../common/motd-banner/motd-banner'
@@ -74,6 +74,9 @@ export const Editor: React.FC = () => {
 
   const onMetadataChange = useCallback((metaData: YAMLMetaData | undefined) => {
     noteMetadata.current = metaData
+    if (metaData) {
+      setDocumentMetadata(metaData)
+    }
     updateDocumentTitle()
   }, [updateDocumentTitle])
 

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -74,9 +74,7 @@ export const Editor: React.FC = () => {
 
   const onMetadataChange = useCallback((metaData: YAMLMetaData | undefined) => {
     noteMetadata.current = metaData
-    if (metaData) {
-      setDocumentMetadata(metaData)
-    }
+    setDocumentMetadata(metaData)
     updateDocumentTitle()
   }, [updateDocumentTitle])
 

--- a/src/components/pad-view-only/pad-view-only.tsx
+++ b/src/components/pad-view-only/pad-view-only.tsx
@@ -44,9 +44,7 @@ export const PadViewOnly: React.FC = () => {
 
   const onMetadataChange = useCallback((metaData: YAMLMetaData | undefined) => {
     noteMetadata.current = metaData
-    if (metaData) {
-      setDocumentMetadata(metaData)
-    }
+    setDocumentMetadata(metaData)
     updateDocumentTitle()
   }, [updateDocumentTitle])
 

--- a/src/components/pad-view-only/pad-view-only.tsx
+++ b/src/components/pad-view-only/pad-view-only.tsx
@@ -11,7 +11,7 @@ import { useParams } from 'react-router'
 import { getNote, Note } from '../../api/notes'
 import { useApplyDarkMode } from '../../hooks/common/use-apply-dark-mode'
 import { useDocumentTitle } from '../../hooks/common/use-document-title'
-import { setDocumentContent } from '../../redux/document-content/methods'
+import { setDocumentContent, setDocumentMetadata } from '../../redux/document-content/methods'
 import { extractNoteTitle } from '../common/document-title/note-title-extractor'
 import { MotdBanner } from '../common/motd-banner/motd-banner'
 import { ShowIf } from '../common/show-if/show-if'
@@ -44,6 +44,9 @@ export const PadViewOnly: React.FC = () => {
 
   const onMetadataChange = useCallback((metaData: YAMLMetaData | undefined) => {
     noteMetadata.current = metaData
+    if (metaData) {
+      setDocumentMetadata(metaData)
+    }
     updateDocumentTitle()
   }, [updateDocumentTitle])
 

--- a/src/redux/document-content/methods.ts
+++ b/src/redux/document-content/methods.ts
@@ -5,12 +5,18 @@
  */
 
 import { store } from '..'
-import { DocumentContentActionType, SetDocumentContentAction, SetNoteIdAction } from './types'
+import { YAMLMetaData } from '../../components/editor/yaml-metadata/yaml-metadata'
+import {
+  DocumentContentActionType,
+  SetDocumentContentAction,
+  SetDocumentMetadataAction,
+  SetNoteIdAction
+} from './types'
 
 export const setDocumentContent = (content: string): void => {
   const action: SetDocumentContentAction = {
     type: DocumentContentActionType.SET_DOCUMENT_CONTENT,
-    content: content
+    content
   }
   store.dispatch(action)
 }
@@ -18,7 +24,15 @@ export const setDocumentContent = (content: string): void => {
 export const setNoteId = (noteId: string): void => {
   const action: SetNoteIdAction = {
     type: DocumentContentActionType.SET_NOTE_ID,
-    noteId: noteId
+    noteId
+  }
+  store.dispatch(action)
+}
+
+export const setDocumentMetadata = (metadata: YAMLMetaData): void => {
+  const action: SetDocumentMetadataAction = {
+    type: DocumentContentActionType.SET_DOCUMENT_METADATA,
+    metadata
   }
   store.dispatch(action)
 }

--- a/src/redux/document-content/methods.ts
+++ b/src/redux/document-content/methods.ts
@@ -29,7 +29,10 @@ export const setNoteId = (noteId: string): void => {
   store.dispatch(action)
 }
 
-export const setDocumentMetadata = (metadata: YAMLMetaData): void => {
+export const setDocumentMetadata = (metadata: YAMLMetaData | undefined): void => {
+  if (!metadata) {
+    return
+  }
   const action: SetDocumentMetadataAction = {
     type: DocumentContentActionType.SET_DOCUMENT_METADATA,
     metadata

--- a/src/redux/document-content/reducers.ts
+++ b/src/redux/document-content/reducers.ts
@@ -9,7 +9,7 @@ import {
   DocumentContent,
   DocumentContentAction,
   DocumentContentActionType,
-  SetDocumentContentAction,
+  SetDocumentContentAction, SetDocumentMetadataAction,
   SetNoteIdAction
 } from './types'
 
@@ -42,6 +42,11 @@ export const DocumentContentReducer: Reducer<DocumentContent, DocumentContentAct
       return {
         ...state,
         noteId: (action as SetNoteIdAction).noteId
+      }
+    case DocumentContentActionType.SET_DOCUMENT_METADATA:
+      return {
+        ...state,
+        metadata: (action as SetDocumentMetadataAction).metadata
       }
     default:
       return state

--- a/src/redux/document-content/reducers.ts
+++ b/src/redux/document-content/reducers.ts
@@ -15,7 +15,20 @@ import {
 
 export const initialState: DocumentContent = {
   content: '',
-  noteId: ''
+  noteId: '',
+  metadata: {
+    title: '',
+    description: '',
+    tags: [],
+    robots: '',
+    lang: 'en',
+    dir: 'ltr',
+    breaks: true,
+    GA: '',
+    disqus: '',
+    type: '',
+    opengraph: new Map<string, string>()
+  }
 }
 
 export const DocumentContentReducer: Reducer<DocumentContent, DocumentContentAction> = (state: DocumentContent = initialState, action: DocumentContentAction) => {

--- a/src/redux/document-content/types.ts
+++ b/src/redux/document-content/types.ts
@@ -5,15 +5,18 @@
  */
 
 import { Action } from 'redux'
+import { YAMLMetaData } from '../../components/editor/yaml-metadata/yaml-metadata'
 
 export enum DocumentContentActionType {
   SET_DOCUMENT_CONTENT = 'document-content/set',
-  SET_NOTE_ID = 'document-content/noteid/set'
+  SET_NOTE_ID = 'document-content/noteid/set',
+  SET_DOCUMENT_METADATA = 'document-content/metadata/set'
 }
 
 export interface DocumentContent {
   content: string
-  noteId: string
+  noteId: string,
+  metadata: YAMLMetaData
 }
 
 export interface DocumentContentAction extends Action<DocumentContentActionType> {
@@ -26,4 +29,8 @@ export interface SetDocumentContentAction extends DocumentContentAction {
 
 export interface SetNoteIdAction extends DocumentContentAction {
   noteId: string
+}
+
+export interface SetDocumentMetadataAction extends DocumentContentAction {
+  metadata: YAMLMetaData
 }


### PR DESCRIPTION
### Component/Part
Editor → document bar → share button

### Description
This PR improves the dialog that opens after clicking the share link button. It now includes two share-able URLs: One for the editor in the current view-mode and one for the read-only-view or presentation-view depending on the note type.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Extended changelog
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
Fixes #790 
Fixes #791 