### PR TITLE
Add support for editor-mode URL parameters

### DIFF
--- a/cypress/integration/editorMode.spec.ts
+++ b/cypress/integration/editorMode.spec.ts
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+describe('Editor mode from URL parameter is used', () => {
+  it('mode view', () => {
+    cy.visit('/n/features?view')
+    cy.get('.splitter.left').should('have.class', 'd-none')
+    cy.get('.splitter.right').should('not.have.class', 'd-none')
+  })
+  it('mode both', () => {
+    cy.visit('/n/features?both')
+    cy.get('.splitter.left').should('not.have.class', 'd-none')
+    cy.get('.splitter.separator').should('exist')
+    cy.get('.splitter.right').should('not.have.class', 'd-none')
+  })
+  it('mode edit', () => {
+    cy.visit('/n/features?edit')
+    cy.get('.splitter.left').should('not.have.class', 'd-none')
+    cy.get('.splitter.right').should('have.class', 'd-none')
+  })
+})

--- a/src/components/editor/app-bar/editor-view-mode.tsx
+++ b/src/components/editor/app-bar/editor-view-mode.tsx
@@ -15,7 +15,7 @@ import { ForkAwesomeIcon } from '../../common/fork-awesome/fork-awesome-icon'
 export enum EditorMode {
   PREVIEW = 'view',
   BOTH = 'both',
-  EDITOR = 'edit',
+  EDITOR = 'edit'
 }
 
 export const EditorViewMode: React.FC = () => {

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 import React, { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
-import { useParams } from 'react-router'
+import { useLocation, useParams } from 'react-router'
 import useMedia from 'use-media'
 import { useApplyDarkMode } from '../../hooks/common/use-apply-dark-mode'
 import { useDocumentTitle } from '../../hooks/common/use-document-title'
@@ -42,6 +42,7 @@ const TASK_REGEX = /(\s*[-*] )(\[[ xX]])( .*)/
 export const Editor: React.FC = () => {
   const { t } = useTranslation()
   const { id } = useParams<EditorPathParams>()
+  const { search } = useLocation()
   const untitledNote = t('editor.untitledNote')
   const markdownContent = useSelector((state: ApplicationState) => state.documentContent.content)
   const isWide = useMedia({ minWidth: 576 })
@@ -60,7 +61,12 @@ export const Editor: React.FC = () => {
 
   useEffect(() => {
     setDocumentContent(editorTestContent)
-  }, [])
+    const requestedMode = search.substr(1)
+    const mode = Object.values(EditorMode).filter(mode => mode === requestedMode)
+    if (mode.length === 1) {
+      setEditorMode(mode[0])
+    }
+  }, [search])
 
   const updateDocumentTitle = useCallback(() => {
     const noteTitle = extractNoteTitle(untitledNote, noteMetadata.current, firstHeading.current)

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -62,9 +62,9 @@ export const Editor: React.FC = () => {
   useEffect(() => {
     setDocumentContent(editorTestContent)
     const requestedMode = search.substr(1)
-    const mode = Object.values(EditorMode).filter(mode => mode === requestedMode)
-    if (mode.length === 1) {
-      setEditorMode(mode[0])
+    const mode = Object.values(EditorMode).find(mode => mode === requestedMode)
+    if (mode) {
+      setEditorMode(mode)
     }
   }, [search])
 


### PR DESCRIPTION
### Component/Part
Editor

### Description
This PR adds support for respecting the editor-mode URL parameters (?both, ?edit, ?view).

When testing this branch, please note that the editor-mode enum has changed and therefore the localStorage-stored-settings won't work anymore unless you once click on one of the edit-view-both buttons once.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
#860 
