### PR TITLE
Replace youtube link with a working one

### DIFF
--- a/src/components/editor/editorTestContent.ts
+++ b/src/components/editor/editorTestContent.ts
@@ -224,7 +224,7 @@ $$
 https://gist.github.com/schacon/1
 
 ## YouTube
-https://www.youtube.com/watch?v=KgMpKsp23yY
+https://www.youtube.com/watch?v=YE7VzlLtp-4
 
 ## Vimeo
 https://vimeo.com/23237102


### PR DESCRIPTION
### Component/Part
Editor demo content

### Description
The youtube video we used in the demo content is down. This PR replaces the old youtube link with big buck bunny.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
