### PR TITLE
Rename npm task

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     },
     "scripts": {
         "start": "PORT=3001 craco start",
-        "start:for-backend": "REACT_APP_BACKEND=http://localhost:3000 yarn start",
+        "start:for-real-backend": "REACT_APP_BACKEND=http://localhost:3000 yarn start",
         "build:serve": "http-server build/ -s -p 3001 -P \"http://127.0.0.1:3001?\"",
         "build": "craco build",
         "analyze": "cross-env ANALYZE=true craco build",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     },
     "scripts": {
         "start": "PORT=3001 craco start",
-        "start:with-backend": "REACT_APP_BACKEND=http://localhost:3000 yarn start",
+        "start:for-backend": "REACT_APP_BACKEND=http://localhost:3000 yarn start",
         "build:serve": "http-server build/ -s -p 3001 -P \"http://127.0.0.1:3001?\"",
         "build": "craco build",
         "analyze": "cross-env ANALYZE=true craco build",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     },
     "scripts": {
         "start": "PORT=3001 craco start",
-        "start:dev": "REACT_APP_BACKEND=http://localhost:3000 yarn start",
+        "start:with-backend": "REACT_APP_BACKEND=http://localhost:3000 yarn start",
         "build:serve": "http-server build/ -s -p 3001 -P \"http://127.0.0.1:3001?\"",
         "build": "craco build",
         "analyze": "cross-env ANALYZE=true craco build",


### PR DESCRIPTION
### Component/Part
NPM task "start:dev"

### Description
IMHO it's very confusing, that there is a task "start" and a task "start:dev", which is for usage with a backend. Therefore I propose to rename the backend task

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
