### PR TITLE
Open links always in new tabs

### DIFF
--- a/src/components/markdown-renderer/hooks/use-replacer-instance-list-creator.ts
+++ b/src/components/markdown-renderer/hooks/use-replacer-instance-list-creator.ts
@@ -9,7 +9,7 @@ import { AbcReplacer } from '../replace-components/abc/abc-replacer'
 import { AsciinemaReplacer } from '../replace-components/asciinema/asciinema-replacer'
 import { ComponentReplacer } from '../replace-components/ComponentReplacer'
 import { CsvReplacer } from '../replace-components/csv/csv-replacer'
-import { ExternalLinksInNewTab } from '../replace-components/external-links-in-new-tabs/external-links-in-new-tabs'
+import { ExternalLinkInNewTabReplacer } from '../replace-components/external-links-in-new-tabs/external-links-in-new-tabs'
 import { FlowchartReplacer } from '../replace-components/flow/flowchart-replacer'
 import { GistReplacer } from '../replace-components/gist/gist-replacer'
 import { GraphvizReplacer } from '../replace-components/graphviz/graphviz-replacer'
@@ -30,7 +30,7 @@ import { YoutubeReplacer } from '../replace-components/youtube/youtube-replacer'
 
 export const useReplacerInstanceListCreator = (onTaskCheckedChange?: (lineInMarkdown: number, checked: boolean) => void): () => ComponentReplacer[] => {
   return useMemo(() => () => [
-    new ExternalLinksInNewTab(),
+    new ExternalLinkInNewTabReplacer(),
     new LinemarkerReplacer(),
     new PossibleWiderReplacer(),
     new GistReplacer(),

--- a/src/components/markdown-renderer/hooks/use-replacer-instance-list-creator.ts
+++ b/src/components/markdown-renderer/hooks/use-replacer-instance-list-creator.ts
@@ -9,6 +9,7 @@ import { AbcReplacer } from '../replace-components/abc/abc-replacer'
 import { AsciinemaReplacer } from '../replace-components/asciinema/asciinema-replacer'
 import { ComponentReplacer } from '../replace-components/ComponentReplacer'
 import { CsvReplacer } from '../replace-components/csv/csv-replacer'
+import { ExternalLinksInNewTab } from '../replace-components/external-links-in-new-tabs/external-links-in-new-tabs'
 import { FlowchartReplacer } from '../replace-components/flow/flowchart-replacer'
 import { GistReplacer } from '../replace-components/gist/gist-replacer'
 import { GraphvizReplacer } from '../replace-components/graphviz/graphviz-replacer'
@@ -29,6 +30,7 @@ import { YoutubeReplacer } from '../replace-components/youtube/youtube-replacer'
 
 export const useReplacerInstanceListCreator = (onTaskCheckedChange?: (lineInMarkdown: number, checked: boolean) => void): () => ComponentReplacer[] => {
   return useMemo(() => () => [
+    new ExternalLinksInNewTab(),
     new LinemarkerReplacer(),
     new PossibleWiderReplacer(),
     new GistReplacer(),

--- a/src/components/markdown-renderer/hooks/use-replacer-instance-list-creator.ts
+++ b/src/components/markdown-renderer/hooks/use-replacer-instance-list-creator.ts
@@ -9,7 +9,7 @@ import { AbcReplacer } from '../replace-components/abc/abc-replacer'
 import { AsciinemaReplacer } from '../replace-components/asciinema/asciinema-replacer'
 import { ComponentReplacer } from '../replace-components/ComponentReplacer'
 import { CsvReplacer } from '../replace-components/csv/csv-replacer'
-import { ExternalLinkInNewTabReplacer } from '../replace-components/external-links-in-new-tabs/external-links-in-new-tabs'
+import { LinkInNewTabReplacer } from '../replace-components/external-links-in-new-tabs/external-links-in-new-tabs'
 import { FlowchartReplacer } from '../replace-components/flow/flowchart-replacer'
 import { GistReplacer } from '../replace-components/gist/gist-replacer'
 import { GraphvizReplacer } from '../replace-components/graphviz/graphviz-replacer'
@@ -30,7 +30,7 @@ import { YoutubeReplacer } from '../replace-components/youtube/youtube-replacer'
 
 export const useReplacerInstanceListCreator = (onTaskCheckedChange?: (lineInMarkdown: number, checked: boolean) => void): () => ComponentReplacer[] => {
   return useMemo(() => () => [
-    new ExternalLinkInNewTabReplacer(),
+    new LinkInNewTabReplacer(),
     new LinemarkerReplacer(),
     new PossibleWiderReplacer(),
     new GistReplacer(),

--- a/src/components/markdown-renderer/markdown-it-plugins/headline-anchors.ts
+++ b/src/components/markdown-renderer/markdown-it-plugins/headline-anchors.ts
@@ -8,11 +8,13 @@ import anchor from '@mrdrogdrog/markdown-it-anchor'
 import MarkdownIt from 'markdown-it'
 
 export const headlineAnchors: MarkdownIt.PluginSimple = (markdownIt) => {
-  // noinspection CheckTagEmptyBody
-  anchor(markdownIt, {
+  const options: anchor.AnchorOptions = {
     permalink: true,
     permalinkBefore: true,
     permalinkClass: 'heading-anchor text-dark',
-    permalinkSymbol: '<i class="fa fa-link"></i>'
-  })
+    permalinkSymbol: '<i class="fa fa-link"></i>',
+    permalinkHref: (slug: string): string => slug
+  }
+
+  anchor(markdownIt, options)
 }

--- a/src/components/markdown-renderer/replace-components/external-links-in-new-tabs/external-links-in-new-tabs.tsx
+++ b/src/components/markdown-renderer/replace-components/external-links-in-new-tabs/external-links-in-new-tabs.tsx
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { DomElement } from 'domhandler'
+import { ReactElement } from 'react'
+import { ComponentReplacer, SubNodeTransform } from '../ComponentReplacer'
+
+export class ExternalLinksInNewTab extends ComponentReplacer {
+  public getReplacement (node: DomElement, subNodeTransform: SubNodeTransform): (ReactElement | null | undefined) {
+    if (node.name !== 'a') {
+      return undefined
+    }
+
+    const isInternalLink = node.attribs?.href?.substr(0, 1) === '#'
+
+    let linkAttributes = {}
+    if (!isInternalLink) {
+      linkAttributes = {
+        rel: 'noopener noreferrer',
+        target: '_blank'
+      }
+    }
+
+    return <a {...node.attribs} {...linkAttributes}>
+      {
+        node.children?.map((child, index) => subNodeTransform(child, index))
+      }
+    </a>
+  }
+}

--- a/src/components/markdown-renderer/replace-components/external-links-in-new-tabs/external-links-in-new-tabs.tsx
+++ b/src/components/markdown-renderer/replace-components/external-links-in-new-tabs/external-links-in-new-tabs.tsx
@@ -7,7 +7,7 @@ import { DomElement } from 'domhandler'
 import { ReactElement } from 'react'
 import { ComponentReplacer, SubNodeTransform } from '../ComponentReplacer'
 
-export class ExternalLinkInNewTabReplacer extends ComponentReplacer {
+export class LinkInNewTabReplacer extends ComponentReplacer {
   public getReplacement (node: DomElement, subNodeTransform: SubNodeTransform): (ReactElement | null | undefined) {
     const isJumpMark = node.attribs?.href?.substr(0, 1) === '#'
 

--- a/src/components/markdown-renderer/replace-components/external-links-in-new-tabs/external-links-in-new-tabs.tsx
+++ b/src/components/markdown-renderer/replace-components/external-links-in-new-tabs/external-links-in-new-tabs.tsx
@@ -7,23 +7,15 @@ import { DomElement } from 'domhandler'
 import { ReactElement } from 'react'
 import { ComponentReplacer, SubNodeTransform } from '../ComponentReplacer'
 
-export class ExternalLinksInNewTab extends ComponentReplacer {
+export class ExternalLinkInNewTabReplacer extends ComponentReplacer {
   public getReplacement (node: DomElement, subNodeTransform: SubNodeTransform): (ReactElement | null | undefined) {
-    if (node.name !== 'a') {
+    const isJumpMark = node.attribs?.href?.substr(0, 1) === '#'
+
+    if (node.name !== 'a' || isJumpMark) {
       return undefined
     }
 
-    const isInternalLink = node.attribs?.href?.substr(0, 1) === '#'
-
-    let linkAttributes = {}
-    if (!isInternalLink) {
-      linkAttributes = {
-        rel: 'noopener noreferrer',
-        target: '_blank'
-      }
-    }
-
-    return <a {...node.attribs} {...linkAttributes}>
+    return <a {...node.attribs} rel='noopener noreferrer' target='_blank'>
       {
         node.children?.map((child, index) => subNodeTransform(child, index))
       }


### PR DESCRIPTION
### Component/Part
Renderer

### Description
This PR adds a new replacer that changes links. External links will always open in a new tab.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
