### PR TITLE
Use original markdown-it-anchor

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "@craco/craco": "6.0.0",
         "@hedgedoc/markdown-it-task-lists": "1.0.0",
         "@matejmazur/react-katex": "3.1.3",
-        "@mrdrogdrog/markdown-it-anchor": "6.0.3",
+        "markdown-it-anchor": "7.0.0",
         "@testing-library/jest-dom": "5.11.8",
         "@testing-library/react": "11.2.2",
         "@testing-library/user-event": "12.6.0",

--- a/src/components/markdown-renderer/markdown-it-plugins/headline-anchors.ts
+++ b/src/components/markdown-renderer/markdown-it-plugins/headline-anchors.ts
@@ -13,7 +13,7 @@ export const headlineAnchors: MarkdownIt.PluginSimple = (markdownIt) => {
     permalinkBefore: true,
     permalinkClass: 'heading-anchor text-dark',
     permalinkSymbol: '<i class="fa fa-link"></i>',
-    permalinkHref: (slug: string): string => slug
+    permalinkHref: (slug: string): string => `#${slug}`
   }
 
   anchor(markdownIt, options)

--- a/src/components/markdown-renderer/markdown-it-plugins/headline-anchors.ts
+++ b/src/components/markdown-renderer/markdown-it-plugins/headline-anchors.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import anchor from '@mrdrogdrog/markdown-it-anchor'
 import MarkdownIt from 'markdown-it'
+import anchor from 'markdown-it-anchor'
 
 export const headlineAnchors: MarkdownIt.PluginSimple = (markdownIt) => {
   const options: anchor.AnchorOptions = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,11 +1513,6 @@
   resolved "https://registry.yarnpkg.com/@matejmazur/react-katex/-/react-katex-3.1.3.tgz#f07404c848b93bfef9ed9653a4bb080dc8bf2bf0"
   integrity sha512-rBp7mJ9An7ktNoU653BWOYdO4FoR4YNwofHZi+vaytX/nWbIlmHVIF+X8VFOn6c3WYmrLT5FFBjKqCZ1sjR5uQ==
 
-"@mrdrogdrog/markdown-it-anchor@6.0.3":
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/@mrdrogdrog/markdown-it-anchor/-/markdown-it-anchor-6.0.3.tgz#83e93561c90b09373de8bbf2d0b0bbf6a63a9803"
-  integrity sha512-YPzFjk3DW4rme2/ZZZ8houoql5nA/1AIoGaiukN4Nkru6LJdJGSmGZx0OO8P52aTgF1WyE21OBod9zbw3Qm/WQ==
-
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
@@ -9554,6 +9549,11 @@ markdown-it-abbr@1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/markdown-it-abbr/-/markdown-it-abbr-1.0.4.tgz#d66b5364521cbb3dd8aa59dadfba2fb6865c8fd8"
   integrity sha1-1mtTZFIcuz3Yqlna37ovtoZcj9g=
+
+markdown-it-anchor@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-7.0.0.tgz#6c43e6a3d3a0b56d0f7e04af7a122834ebbcc311"
+  integrity sha512-7n4ZT58WUoejDDPvk5bxdu/f+BIvRILxs29kPn3YDFJ9tejwOv9Ipw8VpqxXarMjflwYxqpFIYx7whGbLO62nA==
 
 markdown-it-container@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
### Component/Part
Node dependencies

### Description
This PR replaces my fork of markdown-it-anchor with the original version, because it was updated.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
