### PR TITLE
Fix yaml metadata and document title not resetting on deletion

### DIFF
--- a/src/components/markdown-renderer/basic-markdown-renderer.tsx
+++ b/src/components/markdown-renderer/basic-markdown-renderer.tsx
@@ -23,6 +23,7 @@ export interface BasicMarkdownRendererProps {
   markdownIt: MarkdownIt,
   documentReference?: RefObject<HTMLDivElement>
   onBeforeRendering?: () => void
+  onPostRendering?: () => void
 }
 
 export const BasicMarkdownRenderer: React.FC<BasicMarkdownRendererProps & AdditionalMarkdownRendererProps> = ({
@@ -32,7 +33,8 @@ export const BasicMarkdownRenderer: React.FC<BasicMarkdownRendererProps & Additi
   componentReplacers,
   markdownIt,
   documentReference,
-  onBeforeRendering
+  onBeforeRendering,
+  onPostRendering
 }) => {
   const maxLength = useSelector((state: ApplicationState) => state.config.maxDocumentLength)
 
@@ -50,8 +52,12 @@ export const BasicMarkdownRenderer: React.FC<BasicMarkdownRendererProps & Additi
     oldMarkdownLineKeys.current = newLines
     lastUsedLineId.current = newLastUsedLineId
     const transformer = componentReplacers ? buildTransformer(newLines, componentReplacers()) : undefined
-    return ReactHtmlParser(html, { transform: transformer })
-  }, [onBeforeRendering, content, maxLength, markdownIt, componentReplacers])
+    const rendering = ReactHtmlParser(html, { transform: transformer })
+    if (onPostRendering) {
+      onPostRendering()
+    }
+    return rendering
+  }, [onBeforeRendering, onPostRendering, content, maxLength, markdownIt, componentReplacers])
 
   return (
     <div className={`${className || ''} d-flex flex-column align-items-center ${wide ? 'wider' : ''}`}>

--- a/src/components/markdown-renderer/hooks/use-extract-first-headline.ts
+++ b/src/components/markdown-renderer/hooks/use-extract-first-headline.ts
@@ -24,6 +24,8 @@ export const useExtractFirstHeadline = (documentElement: React.RefObject<HTMLDiv
       const firstHeading = documentElement.current.getElementsByTagName('h1').item(0)
       if (firstHeading) {
         onFirstHeadingChange(extractInnerText(firstHeading))
+      } else {
+        onFirstHeadingChange(undefined)
       }
     }
   }, [documentElement, extractInnerText, onFirstHeadingChange, content])

--- a/src/components/markdown-renderer/markdown-it-configurator/FullMarkdownItConfigurator.tsx
+++ b/src/components/markdown-renderer/markdown-it-configurator/FullMarkdownItConfigurator.tsx
@@ -27,7 +27,7 @@ import { BasicMarkdownItConfigurator } from './BasicMarkdownItConfigurator'
 export class FullMarkdownItConfigurator extends BasicMarkdownItConfigurator {
   constructor (
     private useFrontmatter: boolean,
-    private onYamlError: (error: boolean) => void,
+    private passYamlErrorState: (error: boolean) => void,
     private onRawMeta: (rawMeta: RawYAMLMetadata) => void,
     private onToc: (toc: TocAst) => void,
     private onLineMarkers: (lineMarkers: LineMarkers[]) => void
@@ -45,7 +45,7 @@ export class FullMarkdownItConfigurator extends BasicMarkdownItConfigurator {
           !this.useFrontmatter
             ? undefined
             : {
-                onYamlError: (error: boolean) => this.onYamlError(error),
+                onYamlError: (hasError: boolean) => this.passYamlErrorState(hasError),
                 onRawMeta: (rawMeta: RawYAMLMetadata) => this.onRawMeta(rawMeta)
               })
       },

--- a/src/redux/document-content/methods.ts
+++ b/src/redux/document-content/methods.ts
@@ -6,6 +6,7 @@
 
 import { store } from '..'
 import { YAMLMetaData } from '../../components/editor/yaml-metadata/yaml-metadata'
+import { initialState } from './reducers'
 import {
   DocumentContentActionType,
   SetDocumentContentAction,
@@ -31,7 +32,7 @@ export const setNoteId = (noteId: string): void => {
 
 export const setDocumentMetadata = (metadata: YAMLMetaData | undefined): void => {
   if (!metadata) {
-    return
+    metadata = initialState.metadata
   }
   const action: SetDocumentMetadataAction = {
     type: DocumentContentActionType.SET_DOCUMENT_METADATA,


### PR DESCRIPTION
### Component/Part
redux states and title extraction logic

### Description
This PR fixes the fact that yaml-metadata as well as the first heading for the title are cached for too long even if the document has no content anymore.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
