### PR TITLE
Change copyright year from 2020 to 2021

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.idea/copyright/hedgedoc.xml
+++ b/.idea/copyright/hedgedoc.xml
@@ -1,6 +1,6 @@
 <component name="CopyrightManager">
   <copyright>
-    <option name="notice" value="SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)&#10;&#10;&#83;PDX-License-Identifier: AGPL-3.0-only" />
+    <option name="notice" value="SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)&#10;&#10;&#83;PDX-License-Identifier: AGPL-3.0-only" />
     <option name="myName" value="hedgedoc" />
   </copyright>
 </component>

--- a/.mailmap.license
+++ b/.mailmap.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,19 +4,19 @@ Upstream-Contact: The HedgeDoc developers <license@hedgedoc.org>
 Source: https://github.com/hedgedoc/react-client
 
 Files: public/api/*
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: public/icons/*
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: LicenseRef-HedgeDoc-Icon-Usgae-Guidelines
 
 Files: public/locales/*
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC-BY-SA-4.0
 
 Files: public/img/*
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: public/img/highres.jpg
@@ -24,23 +24,23 @@ Copyright: Vincent van Gogh
 License: CC0-1.0
 
 Files: public/index.html
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: public/robots.txt
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: .idea/**
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: .github/ISSUE_TEMPLATE/*.md
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC-BY-SA-4.0
 
 Files: .github/pull_request_template.md
-Copyright: 2020 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
 License: CC-BY-SA-4.0
 
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/browserstack.json.license
+++ b/browserstack.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/craco.config.js
+++ b/craco.config.js
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress.json.license
+++ b/cypress.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/cypress/.eslintrc.json.license
+++ b/cypress/.eslintrc.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/cypress/fixtures/acme.png.license
+++ b/cypress/fixtures/acme.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/cypress/fixtures/import.md.txt.license
+++ b/cypress/fixtures/import.md.txt.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/cypress/fixtures/languages.ts
+++ b/cypress/fixtures/languages.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/autocompletion.spec.ts
+++ b/cypress/integration/autocompletion.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/banner.spec.ts
+++ b/cypress/integration/banner.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/code.spec.ts
+++ b/cypress/integration/code.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/documentTitle.spec.ts
+++ b/cypress/integration/documentTitle.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/editorMode.spec.ts
+++ b/cypress/integration/editorMode.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/export.spec.ts
+++ b/cypress/integration/export.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/helpDialog.spec.ts
+++ b/cypress/integration/helpDialog.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/history.spec.ts
+++ b/cypress/integration/history.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/import.spec.ts
+++ b/cypress/integration/import.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/intro.spec.ts
+++ b/cypress/integration/intro.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/language.spec.ts
+++ b/cypress/integration/language.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/link.spec.ts
+++ b/cypress/integration/link.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/maxLength.spec.ts
+++ b/cypress/integration/maxLength.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/metadata.spec.ts
+++ b/cypress/integration/metadata.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/profile.spec.ts
+++ b/cypress/integration/profile.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/toolbar.spec.ts
+++ b/cypress/integration/toolbar.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/upload.spec.ts
+++ b/cypress/integration/upload.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/support/checkLinks.ts
+++ b/cypress/support/checkLinks.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/support/config.ts
+++ b/cypress/support/config.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/support/fill.ts
+++ b/cypress/support/fill.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/support/login.ts
+++ b/cypress/support/login.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/tsconfig.json.license
+++ b/cypress/tsconfig.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/cypress/webpack.config.js
+++ b/cypress/webpack.config.js
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: CC0-1.0
  */

--- a/package.json.license
+++ b/package.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/renovate.json.license
+++ b/renovate.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/config/types.d.ts
+++ b/src/api/config/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/me/index.ts
+++ b/src/api/me/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/media/index.ts
+++ b/src/api/media/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/notes/index.ts
+++ b/src/api/notes/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/revisions/index.ts
+++ b/src/api/revisions/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/revisions/types.d.ts
+++ b/src/api/revisions/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/tokens/index.ts
+++ b/src/api/tokens/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/tokens/types.d.ts
+++ b/src/api/tokens/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/users/index.ts
+++ b/src/api/users/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/users/types.d.ts
+++ b/src/api/users/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/application-loader/application-loader.scss
+++ b/src/components/application-loader/application-loader.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/application-loader/application-loader.tsx
+++ b/src/components/application-loader/application-loader.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/application-loader/initializers/configLoader.ts
+++ b/src/components/application-loader/initializers/configLoader.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/application-loader/initializers/i18n.ts
+++ b/src/components/application-loader/initializers/i18n.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/application-loader/initializers/index.ts
+++ b/src/components/application-loader/initializers/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/application-loader/loading-screen.tsx
+++ b/src/components/application-loader/loading-screen.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/branding/branding.scss
+++ b/src/components/common/branding/branding.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/branding/branding.tsx
+++ b/src/components/common/branding/branding.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/cache/cache.test.ts
+++ b/src/components/common/cache/cache.test.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/cache/cache.ts
+++ b/src/components/common/cache/cache.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/copyable/copy-overlay.tsx
+++ b/src/components/common/copyable/copy-overlay.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/copyable/copy-to-clipboard-button/copy-to-clipboard-button.tsx
+++ b/src/components/common/copyable/copy-to-clipboard-button/copy-to-clipboard-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/copyable/copyable-field/copyable-field.tsx
+++ b/src/components/common/copyable/copyable-field/copyable-field.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/document-title/note-title-extractor.ts
+++ b/src/components/common/document-title/note-title-extractor.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/download/download.ts
+++ b/src/components/common/download/download.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/fork-awesome/fork-awesome-icon.tsx
+++ b/src/components/common/fork-awesome/fork-awesome-icon.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/fork-awesome/fork-awesome-stack.tsx
+++ b/src/components/common/fork-awesome/fork-awesome-stack.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/fork-awesome/types.d.ts
+++ b/src/components/common/fork-awesome/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/hedge-doc-logo/hedge-doc-logo-with-text.tsx
+++ b/src/components/common/hedge-doc-logo/hedge-doc-logo-with-text.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/hedge-doc-logo/hedge-doc-logo.tsx
+++ b/src/components/common/hedge-doc-logo/hedge-doc-logo.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/hedge-doc-logo/logo_color.svg.license
+++ b/src/components/common/hedge-doc-logo/logo_color.svg.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: LicenseRef-HedgeDoc-Icon-Usgae-Guidelines

--- a/src/components/common/hedge-doc-logo/logo_text_bw_horizontal.svg.license
+++ b/src/components/common/hedge-doc-logo/logo_text_bw_horizontal.svg.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: LicenseRef-HedgeDoc-Icon-Usgae-Guidelines

--- a/src/components/common/hedge-doc-logo/logo_text_color_vertical.svg.license
+++ b/src/components/common/hedge-doc-logo/logo_text_color_vertical.svg.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: LicenseRef-HedgeDoc-Icon-Usgae-Guidelines

--- a/src/components/common/hedge-doc-logo/logo_text_wb_horizontal.svg.license
+++ b/src/components/common/hedge-doc-logo/logo_text_wb_horizontal.svg.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: LicenseRef-HedgeDoc-Icon-Usgae-Guidelines

--- a/src/components/common/hidden-input-menu-entry/hidden-input-menu-entry.tsx
+++ b/src/components/common/hidden-input-menu-entry/hidden-input-menu-entry.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/hljs/hljs.ts
+++ b/src/components/common/hljs/hljs.ts
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/icon-button/icon-button.scss
+++ b/src/components/common/icon-button/icon-button.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/icon-button/icon-button.tsx
+++ b/src/components/common/icon-button/icon-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/icon-button/translated-icon-button.tsx
+++ b/src/components/common/icon-button/translated-icon-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/links/external-link.tsx
+++ b/src/components/common/links/external-link.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/links/internal-link.tsx
+++ b/src/components/common/links/internal-link.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/links/translated-external-link.tsx
+++ b/src/components/common/links/translated-external-link.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/links/translated-internal-link.tsx
+++ b/src/components/common/links/translated-internal-link.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/links/types.d.ts
+++ b/src/components/common/links/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/lock-button/lock-button.tsx
+++ b/src/components/common/lock-button/lock-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/modals/common-modal.tsx
+++ b/src/components/common/modals/common-modal.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/modals/deletion-modal.tsx
+++ b/src/components/common/modals/deletion-modal.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/modals/error-modal.tsx
+++ b/src/components/common/modals/error-modal.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/motd-banner/motd-banner.tsx
+++ b/src/components/common/motd-banner/motd-banner.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/number-range/number-range.ts
+++ b/src/components/common/number-range/number-range.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/pagination/pager-item.tsx
+++ b/src/components/common/pagination/pager-item.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/pagination/pager-pagination.tsx
+++ b/src/components/common/pagination/pager-pagination.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/pagination/pager.tsx
+++ b/src/components/common/pagination/pager.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/routing/not-found-error-screen.tsx
+++ b/src/components/common/routing/not-found-error-screen.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/routing/redirector.tsx
+++ b/src/components/common/routing/redirector.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/show-if/show-if.tsx
+++ b/src/components/common/show-if/show-if.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/common/user-avatar/user-avatar.scss
+++ b/src/components/common/user-avatar/user-avatar.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/user-avatar/user-avatar.tsx
+++ b/src/components/common/user-avatar/user-avatar.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/app-bar/app-bar.tsx
+++ b/src/components/editor/app-bar/app-bar.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/app-bar/dark-mode-button.tsx
+++ b/src/components/editor/app-bar/dark-mode-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/app-bar/editor-view-mode.tsx
+++ b/src/components/editor/app-bar/editor-view-mode.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/app-bar/help-button/cheatsheet.scss
+++ b/src/components/editor/app-bar/help-button/cheatsheet.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/app-bar/help-button/cheatsheet.tsx
+++ b/src/components/editor/app-bar/help-button/cheatsheet.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/app-bar/help-button/help-button.tsx
+++ b/src/components/editor/app-bar/help-button/help-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/app-bar/help-button/links.tsx
+++ b/src/components/editor/app-bar/help-button/links.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/app-bar/help-button/shortcuts.tsx
+++ b/src/components/editor/app-bar/help-button/shortcuts.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/app-bar/navbar-branding.tsx
+++ b/src/components/editor/app-bar/navbar-branding.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/app-bar/sync-scroll-buttons/buttonIcon.svg.license
+++ b/src/components/editor/app-bar/sync-scroll-buttons/buttonIcon.svg.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/src/components/editor/app-bar/sync-scroll-buttons/disabledScroll.svg.license
+++ b/src/components/editor/app-bar/sync-scroll-buttons/disabledScroll.svg.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/src/components/editor/app-bar/sync-scroll-buttons/enabledScroll.svg.license
+++ b/src/components/editor/app-bar/sync-scroll-buttons/enabledScroll.svg.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/src/components/editor/app-bar/sync-scroll-buttons/sync-scroll-buttons.scss
+++ b/src/components/editor/app-bar/sync-scroll-buttons/sync-scroll-buttons.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/app-bar/sync-scroll-buttons/sync-scroll-buttons.tsx
+++ b/src/components/editor/app-bar/sync-scroll-buttons/sync-scroll-buttons.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/buttons/pin-to-history-button.tsx
+++ b/src/components/editor/document-bar/buttons/pin-to-history-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/buttons/share-link-button.tsx
+++ b/src/components/editor/document-bar/buttons/share-link-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/connection-indicator/active-indicator.scss
+++ b/src/components/editor/document-bar/connection-indicator/active-indicator.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/document-bar/connection-indicator/active-indicator.tsx
+++ b/src/components/editor/document-bar/connection-indicator/active-indicator.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/connection-indicator/connection-indicator.tsx
+++ b/src/components/editor/document-bar/connection-indicator/connection-indicator.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/connection-indicator/user-line.scss
+++ b/src/components/editor/document-bar/connection-indicator/user-line.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/document-bar/connection-indicator/user-line.tsx
+++ b/src/components/editor/document-bar/connection-indicator/user-line.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/document-bar.tsx
+++ b/src/components/editor/document-bar/document-bar.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/document-info/document-info-button.tsx
+++ b/src/components/editor/document-bar/document-info/document-info-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/document-info/document-info-line.tsx
+++ b/src/components/editor/document-bar/document-info/document-info-line.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/document-info/document-info-time-line.tsx
+++ b/src/components/editor/document-bar/document-info/document-info-time-line.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/document-info/time-from-now.tsx
+++ b/src/components/editor/document-bar/document-info/time-from-now.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/document-info/unitalic-bold-text.tsx
+++ b/src/components/editor/document-bar/document-info/unitalic-bold-text.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/menus/editor-menu.tsx
+++ b/src/components/editor/document-bar/menus/editor-menu.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/menus/export-menu.tsx
+++ b/src/components/editor/document-bar/menus/export-menu.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/menus/export/markdown.tsx
+++ b/src/components/editor/document-bar/menus/export/markdown.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/menus/import-menu.tsx
+++ b/src/components/editor/document-bar/menus/import-menu.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/permissions/permission-button.tsx
+++ b/src/components/editor/document-bar/permissions/permission-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/permissions/permission-group-entry.tsx
+++ b/src/components/editor/document-bar/permissions/permission-group-entry.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/permissions/permission-list.tsx
+++ b/src/components/editor/document-bar/permissions/permission-list.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/permissions/permission-modal.tsx
+++ b/src/components/editor/document-bar/permissions/permission-modal.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/revisions/revision-button.tsx
+++ b/src/components/editor/document-bar/revisions/revision-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/revisions/revision-modal-list-entry.tsx
+++ b/src/components/editor/document-bar/revisions/revision-modal-list-entry.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/revisions/revision-modal.scss
+++ b/src/components/editor/document-bar/revisions/revision-modal.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/document-bar/revisions/revision-modal.tsx
+++ b/src/components/editor/document-bar/revisions/revision-modal.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-bar/revisions/utils.ts
+++ b/src/components/editor/document-bar/revisions/utils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/document-renderer-pane/document-render-pane.tsx
+++ b/src/components/editor/document-renderer-pane/document-render-pane.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/document-renderer-pane/scrolling-document-render-pane.tsx
+++ b/src/components/editor/document-renderer-pane/scrolling-document-render-pane.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/editor-modals/max-length-warning-modal.tsx
+++ b/src/components/editor/editor-modals/max-length-warning-modal.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/editor-pane/autocompletion/code-block.ts
+++ b/src/components/editor/editor-pane/autocompletion/code-block.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/autocompletion/collapsable-block.ts
+++ b/src/components/editor/editor-pane/autocompletion/collapsable-block.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/autocompletion/container.ts
+++ b/src/components/editor/editor-pane/autocompletion/container.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/autocompletion/emoji.ts
+++ b/src/components/editor/editor-pane/autocompletion/emoji.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/autocompletion/header.ts
+++ b/src/components/editor/editor-pane/autocompletion/header.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/autocompletion/image.ts
+++ b/src/components/editor/editor-pane/autocompletion/image.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/autocompletion/index.ts
+++ b/src/components/editor/editor-pane/autocompletion/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/autocompletion/link-and-extra-tag.ts
+++ b/src/components/editor/editor-pane/autocompletion/link-and-extra-tag.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/autocompletion/pdf.ts
+++ b/src/components/editor/editor-pane/autocompletion/pdf.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/editor-pane.scss
+++ b/src/components/editor/editor-pane/editor-pane.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/editor-pane.tsx
+++ b/src/components/editor/editor-pane/editor-pane.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/editor-pane/hints.scss
+++ b/src/components/editor/editor-pane/hints.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/key-map.ts
+++ b/src/components/editor/editor-pane/key-map.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/status-bar/status-bar.scss
+++ b/src/components/editor/editor-pane/status-bar/status-bar.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/status-bar/status-bar.tsx
+++ b/src/components/editor/editor-pane/status-bar/status-bar.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/editor-pane/tool-bar/editor-preferences/editor-preference-boolean-property.tsx
+++ b/src/components/editor/editor-pane/tool-bar/editor-preferences/editor-preference-boolean-property.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/editor-pane/tool-bar/editor-preferences/editor-preference-input.tsx
+++ b/src/components/editor/editor-pane/tool-bar/editor-preferences/editor-preference-input.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/tool-bar/editor-preferences/editor-preference-ligatures-select.tsx
+++ b/src/components/editor/editor-pane/tool-bar/editor-preferences/editor-preference-ligatures-select.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/tool-bar/editor-preferences/editor-preference-number-property.tsx
+++ b/src/components/editor/editor-pane/tool-bar/editor-preferences/editor-preference-number-property.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/editor-pane/tool-bar/editor-preferences/editor-preference-property.ts
+++ b/src/components/editor/editor-pane/tool-bar/editor-preferences/editor-preference-property.ts
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/editor-pane/tool-bar/editor-preferences/editor-preference-select-property.tsx
+++ b/src/components/editor/editor-pane/tool-bar/editor-preferences/editor-preference-select-property.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/editor-pane/tool-bar/editor-preferences/editor-preferences.tsx
+++ b/src/components/editor/editor-pane/tool-bar/editor-preferences/editor-preferences.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/editor-pane/tool-bar/emoji-picker/emoji-picker-button.tsx
+++ b/src/components/editor/editor-pane/tool-bar/emoji-picker/emoji-picker-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/editor-pane/tool-bar/emoji-picker/emoji-picker.scss
+++ b/src/components/editor/editor-pane/tool-bar/emoji-picker/emoji-picker.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/tool-bar/emoji-picker/emoji-picker.tsx
+++ b/src/components/editor/editor-pane/tool-bar/emoji-picker/emoji-picker.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/editor-pane/tool-bar/emoji-picker/icon-names.ts
+++ b/src/components/editor/editor-pane/tool-bar/emoji-picker/icon-names.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/tool-bar/table-picker/custom-table-size-modal.tsx
+++ b/src/components/editor/editor-pane/tool-bar/table-picker/custom-table-size-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/tool-bar/table-picker/table-picker-button.tsx
+++ b/src/components/editor/editor-pane/tool-bar/table-picker/table-picker-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/tool-bar/table-picker/table-picker.scss
+++ b/src/components/editor/editor-pane/tool-bar/table-picker/table-picker.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/tool-bar/table-picker/table-picker.tsx
+++ b/src/components/editor/editor-pane/tool-bar/table-picker/table-picker.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/tool-bar/tool-bar.scss
+++ b/src/components/editor/editor-pane/tool-bar/tool-bar.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/tool-bar/tool-bar.tsx
+++ b/src/components/editor/editor-pane/tool-bar/tool-bar.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/editor-pane/tool-bar/utils/emojiUtils.ts
+++ b/src/components/editor/editor-pane/tool-bar/utils/emojiUtils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/tool-bar/utils/toolbarButtonUtils.test.disabled.ts
+++ b/src/components/editor/editor-pane/tool-bar/utils/toolbarButtonUtils.test.disabled.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/tool-bar/utils/toolbarButtonUtils.ts
+++ b/src/components/editor/editor-pane/tool-bar/utils/toolbarButtonUtils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/tool-bar/utils/upload-image-mimetypes.ts
+++ b/src/components/editor/editor-pane/tool-bar/utils/upload-image-mimetypes.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor-pane/upload-handler.ts
+++ b/src/components/editor/editor-pane/upload-handler.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/editorTestContent.ts
+++ b/src/components/editor/editorTestContent.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/hooks/useViewModeShortcuts.ts
+++ b/src/components/editor/hooks/useViewModeShortcuts.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/scroll/hooks/use-scroll-to-line-mark.ts
+++ b/src/components/editor/scroll/hooks/use-scroll-to-line-mark.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/scroll/hooks/use-user-scroll.ts
+++ b/src/components/editor/scroll/hooks/use-user-scroll.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/scroll/scroll-props.ts
+++ b/src/components/editor/scroll/scroll-props.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/scroll/utils.ts
+++ b/src/components/editor/scroll/utils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/splitter/split-divider/split-divider.scss
+++ b/src/components/editor/splitter/split-divider/split-divider.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/splitter/split-divider/split-divider.tsx
+++ b/src/components/editor/splitter/split-divider/split-divider.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/splitter/splitter.scss
+++ b/src/components/editor/splitter/splitter.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/splitter/splitter.tsx
+++ b/src/components/editor/splitter/splitter.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/table-of-contents/table-of-contents.scss
+++ b/src/components/editor/table-of-contents/table-of-contents.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/table-of-contents/table-of-contents.tsx
+++ b/src/components/editor/table-of-contents/table-of-contents.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/editor/utils.ts
+++ b/src/components/editor/utils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/yaml-metadata/yaml-metadata.test.ts
+++ b/src/components/editor/yaml-metadata/yaml-metadata.test.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor/yaml-metadata/yaml-metadata.ts
+++ b/src/components/editor/yaml-metadata/yaml-metadata.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/error-boundary/error-boundary.tsx
+++ b/src/components/error-boundary/error-boundary.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/entry-menu/delete-note-item.tsx
+++ b/src/components/history-page/entry-menu/delete-note-item.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/entry-menu/dropdown-item-with-deletion-modal.tsx
+++ b/src/components/history-page/entry-menu/dropdown-item-with-deletion-modal.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/entry-menu/entry-menu.scss
+++ b/src/components/history-page/entry-menu/entry-menu.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/entry-menu/entry-menu.tsx
+++ b/src/components/history-page/entry-menu/entry-menu.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/entry-menu/remove-note-entry-item.tsx
+++ b/src/components/history-page/entry-menu/remove-note-entry-item.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/history-card/history-card-list.tsx
+++ b/src/components/history-page/history-card/history-card-list.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/history-card/history-card.scss
+++ b/src/components/history-page/history-card/history-card.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-card/history-card.tsx
+++ b/src/components/history-page/history-card/history-card.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/history-content/history-content.tsx
+++ b/src/components/history-page/history-content/history-content.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/history-page.tsx
+++ b/src/components/history-page/history-page.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/history-table/history-table-row.tsx
+++ b/src/components/history-page/history-table/history-table-row.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/history-table/history-table.scss
+++ b/src/components/history-page/history-table/history-table.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-table/history-table.tsx
+++ b/src/components/history-page/history-table/history-table.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/history-toolbar/clear-history-button.tsx
+++ b/src/components/history-page/history-toolbar/clear-history-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/history-toolbar/export-history-button.tsx
+++ b/src/components/history-page/history-toolbar/export-history-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/history-toolbar/history-toolbar.tsx
+++ b/src/components/history-page/history-toolbar/history-toolbar.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/history-toolbar/import-history-button.tsx
+++ b/src/components/history-page/history-toolbar/import-history-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/history-toolbar/typeahead-hacks.scss
+++ b/src/components/history-page/history-toolbar/typeahead-hacks.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/pin-button/pin-button.scss
+++ b/src/components/history-page/pin-button/pin-button.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/pin-button/pin-button.tsx
+++ b/src/components/history-page/pin-button/pin-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/sort-button/sort-button.tsx
+++ b/src/components/history-page/sort-button/sort-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/history-page/utils.ts
+++ b/src/components/history-page/utils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/intro-page/cover-buttons/cover-buttons.scss
+++ b/src/components/intro-page/cover-buttons/cover-buttons.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/intro-page/cover-buttons/cover-buttons.tsx
+++ b/src/components/intro-page/cover-buttons/cover-buttons.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/intro-page/feature-links.tsx
+++ b/src/components/intro-page/feature-links.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/intro-page/img/screenshot.png.license
+++ b/src/components/intro-page/img/screenshot.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/src/components/intro-page/intro-page.tsx
+++ b/src/components/intro-page/intro-page.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/landing-layout/footer/footer.tsx
+++ b/src/components/landing-layout/footer/footer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/landing-layout/footer/language-picker.tsx
+++ b/src/components/landing-layout/footer/language-picker.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/landing-layout/footer/powered-by-links.tsx
+++ b/src/components/landing-layout/footer/powered-by-links.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/landing-layout/footer/social-links.tsx
+++ b/src/components/landing-layout/footer/social-links.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/landing-layout/footer/version-info.tsx
+++ b/src/components/landing-layout/footer/version-info.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/landing-layout/landing-layout.tsx
+++ b/src/components/landing-layout/landing-layout.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/landing-layout/navigation/header-bar/header-bar.scss
+++ b/src/components/landing-layout/navigation/header-bar/header-bar.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/navigation/header-bar/header-bar.tsx
+++ b/src/components/landing-layout/navigation/header-bar/header-bar.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/landing-layout/navigation/header-nav-link.tsx
+++ b/src/components/landing-layout/navigation/header-nav-link.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/landing-layout/navigation/new-guest-note-button.tsx
+++ b/src/components/landing-layout/navigation/new-guest-note-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/landing-layout/navigation/new-user-note-button.tsx
+++ b/src/components/landing-layout/navigation/new-user-note-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/landing-layout/navigation/sign-in-button.tsx
+++ b/src/components/landing-layout/navigation/sign-in-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/landing-layout/navigation/user-dropdown.tsx
+++ b/src/components/landing-layout/navigation/user-dropdown.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/login-page/auth/social-link-button/social-link-button.scss
+++ b/src/components/login-page/auth/social-link-button/social-link-button.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/login-page/auth/social-link-button/social-link-button.tsx
+++ b/src/components/login-page/auth/social-link-button/social-link-button.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/login-page/auth/utils.ts
+++ b/src/components/login-page/auth/utils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/login-page/auth/via-internal.tsx
+++ b/src/components/login-page/auth/via-internal.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/login-page/auth/via-ldap.tsx
+++ b/src/components/login-page/auth/via-ldap.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/login-page/auth/via-one-click.tsx
+++ b/src/components/login-page/auth/via-one-click.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/login-page/auth/via-openid.tsx
+++ b/src/components/login-page/auth/via-openid.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/login-page/login-page.tsx
+++ b/src/components/login-page/login-page.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/basic-markdown-renderer.tsx
+++ b/src/components/markdown-renderer/basic-markdown-renderer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/full-markdown-renderer.tsx
+++ b/src/components/markdown-renderer/full-markdown-renderer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/hooks/use-extract-first-headline.ts
+++ b/src/components/markdown-renderer/hooks/use-extract-first-headline.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/hooks/use-post-meta-data-on-change.ts
+++ b/src/components/markdown-renderer/hooks/use-post-meta-data-on-change.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/hooks/use-post-toc-ast-on-change.ts
+++ b/src/components/markdown-renderer/hooks/use-post-toc-ast-on-change.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/hooks/use-replacer-instance-list-creator.ts
+++ b/src/components/markdown-renderer/hooks/use-replacer-instance-list-creator.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-it-configurator/BasicMarkdownItConfigurator.tsx
+++ b/src/components/markdown-renderer/markdown-it-configurator/BasicMarkdownItConfigurator.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/markdown-it-configurator/FullMarkdownItConfigurator.tsx
+++ b/src/components/markdown-renderer/markdown-it-configurator/FullMarkdownItConfigurator.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/markdown-it-configurator/MarkdownItConfigurator.tsx
+++ b/src/components/markdown-renderer/markdown-it-configurator/MarkdownItConfigurator.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/markdown-it-plugins/alert-container.ts
+++ b/src/components/markdown-renderer/markdown-it-plugins/alert-container.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-it-plugins/document-toc.ts
+++ b/src/components/markdown-renderer/markdown-it-plugins/document-toc.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-it-plugins/emoji/mapping.ts
+++ b/src/components/markdown-renderer/markdown-it-plugins/emoji/mapping.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-it-plugins/frontmatter.ts
+++ b/src/components/markdown-renderer/markdown-it-plugins/frontmatter.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-it-plugins/headline-anchors.ts
+++ b/src/components/markdown-renderer/markdown-it-plugins/headline-anchors.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-it-plugins/highlighted-code.ts
+++ b/src/components/markdown-renderer/markdown-it-plugins/highlighted-code.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-it-plugins/linkify-extra.ts
+++ b/src/components/markdown-renderer/markdown-it-plugins/linkify-extra.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-it-plugins/parser-debugger.ts
+++ b/src/components/markdown-renderer/markdown-it-plugins/parser-debugger.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-it-plugins/plantuml.ts
+++ b/src/components/markdown-renderer/markdown-it-plugins/plantuml.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-it-plugins/quote-extra.ts
+++ b/src/components/markdown-renderer/markdown-it-plugins/quote-extra.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-it-plugins/tasks-lists.ts
+++ b/src/components/markdown-renderer/markdown-it-plugins/tasks-lists.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-it-plugins/twitter-emojis.ts
+++ b/src/components/markdown-renderer/markdown-it-plugins/twitter-emojis.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-renderer.scss
+++ b/src/components/markdown-renderer/markdown-renderer.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/regex-plugins/replace-legacy-slideshare-short-code.ts
+++ b/src/components/markdown-renderer/regex-plugins/replace-legacy-slideshare-short-code.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/regex-plugins/replace-legacy-speakerdeck-short-code.ts
+++ b/src/components/markdown-renderer/regex-plugins/replace-legacy-speakerdeck-short-code.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/ComponentReplacer.ts
+++ b/src/components/markdown-renderer/replace-components/ComponentReplacer.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/abc/abc-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/abc/abc-frame.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/abc/abc-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/abc/abc-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/asciinema/asciinema-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/asciinema/asciinema-frame.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/asciinema/asciinema-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/asciinema/asciinema-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/asciinema/replace-asciinema-link.ts
+++ b/src/components/markdown-renderer/replace-components/asciinema/replace-asciinema-link.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/csv/csv-parser.test.ts
+++ b/src/components/markdown-renderer/replace-components/csv/csv-parser.test.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/csv/csv-parser.ts
+++ b/src/components/markdown-renderer/replace-components/csv/csv-parser.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/csv/csv-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/csv/csv-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/csv/csv-table.tsx
+++ b/src/components/markdown-renderer/replace-components/csv/csv-table.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/external-links-in-new-tabs/external-links-in-new-tabs.tsx
+++ b/src/components/markdown-renderer/replace-components/external-links-in-new-tabs/external-links-in-new-tabs.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/flow/flowchart-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/flow/flowchart-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/flow/flowchart/flowchart.tsx
+++ b/src/components/markdown-renderer/replace-components/flow/flowchart/flowchart.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/gist/gist-frame.scss
+++ b/src/components/markdown-renderer/replace-components/gist/gist-frame.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/gist/gist-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/gist/gist-frame.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/gist/gist-preview.png.license
+++ b/src/components/markdown-renderer/replace-components/gist/gist-preview.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/src/components/markdown-renderer/replace-components/gist/gist-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/gist/gist-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/gist/replace-gist-link.ts
+++ b/src/components/markdown-renderer/replace-components/gist/replace-gist-link.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/gist/replace-legacy-gist-short-code.ts
+++ b/src/components/markdown-renderer/replace-components/gist/replace-legacy-gist-short-code.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/graphviz/graphviz-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/graphviz/graphviz-frame.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/graphviz/graphviz-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/graphviz/graphviz-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.scss
+++ b/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.tsx
+++ b/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-fence-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-fence-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/image/image-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/image/image-frame.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/image/image-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/image/image-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/image/lightboxedImageFrame.tsx
+++ b/src/components/markdown-renderer/replace-components/image/lightboxedImageFrame.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/image/types.ts
+++ b/src/components/markdown-renderer/replace-components/image/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/katex/katex-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/katex/katex-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/katex/katex.scss
+++ b/src/components/markdown-renderer/replace-components/katex/katex.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/linemarker/line-number-marker.ts
+++ b/src/components/markdown-renderer/replace-components/linemarker/line-number-marker.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/linemarker/linemarker-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/linemarker/linemarker-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/markmap/markmap-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/markmap/markmap-frame.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/markmap/markmap-loader.ts
+++ b/src/components/markdown-renderer/replace-components/markmap/markmap-loader.ts
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/markmap/markmap-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/markmap/markmap-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/mermaid/mermaid-chart.tsx
+++ b/src/components/markdown-renderer/replace-components/mermaid/mermaid-chart.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/mermaid/mermaid-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/mermaid/mermaid-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/mermaid/mermaid.scss
+++ b/src/components/markdown-renderer/replace-components/mermaid/mermaid.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/one-click-frame/one-click-embedding.scss
+++ b/src/components/markdown-renderer/replace-components/one-click-frame/one-click-embedding.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/one-click-frame/one-click-embedding.tsx
+++ b/src/components/markdown-renderer/replace-components/one-click-frame/one-click-embedding.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/pdf/pdf-frame.scss
+++ b/src/components/markdown-renderer/replace-components/pdf/pdf-frame.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/pdf/pdf-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/pdf/pdf-frame.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/pdf/pdf-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/pdf/pdf-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/pdf/replace-pdf-short-code.ts
+++ b/src/components/markdown-renderer/replace-components/pdf/replace-pdf-short-code.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/possible-wider/possible-wider-replacer.scss
+++ b/src/components/markdown-renderer/replace-components/possible-wider/possible-wider-replacer.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/possible-wider/possible-wider-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/possible-wider/possible-wider-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/quote-options/quote-options-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/quote-options/quote-options-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/sequence-diagram/deprecation-warning.tsx
+++ b/src/components/markdown-renderer/replace-components/sequence-diagram/deprecation-warning.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/sequence-diagram/sequence-diagram-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/sequence-diagram/sequence-diagram-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/task-list/task-list-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/task-list/task-list-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/utils.ts
+++ b/src/components/markdown-renderer/replace-components/utils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/vega-lite/vega-chart.tsx
+++ b/src/components/markdown-renderer/replace-components/vega-lite/vega-chart.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/vega-lite/vega-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/vega-lite/vega-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/vimeo/replace-legacy-vimeo-short-code.ts
+++ b/src/components/markdown-renderer/replace-components/vimeo/replace-legacy-vimeo-short-code.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/vimeo/replace-vimeo-link.ts
+++ b/src/components/markdown-renderer/replace-components/vimeo/replace-vimeo-link.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/vimeo/vimeo-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/vimeo/vimeo-frame.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/vimeo/vimeo-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/vimeo/vimeo-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/youtube/replace-legacy-youtube-short-code.ts
+++ b/src/components/markdown-renderer/replace-components/youtube/replace-legacy-youtube-short-code.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/youtube/replace-youtube-link.ts
+++ b/src/components/markdown-renderer/replace-components/youtube/replace-youtube-link.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/youtube/youtube-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/youtube/youtube-frame.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/replace-components/youtube/youtube-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/youtube/youtube-replacer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/types.d.ts
+++ b/src/components/markdown-renderer/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/utils/button-inside.scss
+++ b/src/components/markdown-renderer/utils/button-inside.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/utils/calculate-line-marker-positions.ts
+++ b/src/components/markdown-renderer/utils/calculate-line-marker-positions.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/utils/html-react-transformer.tsx
+++ b/src/components/markdown-renderer/utils/html-react-transformer.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/markdown-renderer/utils/line-number-mapping.ts
+++ b/src/components/markdown-renderer/utils/line-number-mapping.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/pad-view-only/document-infobar.scss
+++ b/src/components/pad-view-only/document-infobar.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/pad-view-only/document-infobar.tsx
+++ b/src/components/pad-view-only/document-infobar.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/pad-view-only/pad-view-only.tsx
+++ b/src/components/pad-view-only/pad-view-only.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/profile-page/access-tokens/profile-access-tokens.tsx
+++ b/src/components/profile-page/access-tokens/profile-access-tokens.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/profile-page/profile-page.tsx
+++ b/src/components/profile-page/profile-page.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/profile-page/settings/profile-account-management.tsx
+++ b/src/components/profile-page/settings/profile-account-management.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/profile-page/settings/profile-change-password.tsx
+++ b/src/components/profile-page/settings/profile-change-password.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/profile-page/settings/profile-display-name.tsx
+++ b/src/components/profile-page/settings/profile-display-name.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/components/register-page/register-page.tsx
+++ b/src/components/register-page/register-page.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/external-types/abcjs/abcjs.d.ts
+++ b/src/external-types/abcjs/abcjs.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-abbr/index.d.ts
+++ b/src/external-types/markdown-it-abbr/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-deflist/index.d.ts
+++ b/src/external-types/markdown-it-deflist/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-emoji/index.d.ts
+++ b/src/external-types/markdown-it-emoji/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-emoji/interface.d.ts
+++ b/src/external-types/markdown-it-emoji/interface.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-footnote/index.d.ts
+++ b/src/external-types/markdown-it-footnote/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-front-matter/index.d.ts
+++ b/src/external-types/markdown-it-front-matter/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-imsize/index.d.ts
+++ b/src/external-types/markdown-it-imsize/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-imsize/interface.ts
+++ b/src/external-types/markdown-it-imsize/interface.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-ins/index.d.ts
+++ b/src/external-types/markdown-it-ins/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-linkify/index.d.ts
+++ b/src/external-types/markdown-it-linkify/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-mark/index.d.ts
+++ b/src/external-types/markdown-it-mark/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-mathjax/index.d.ts
+++ b/src/external-types/markdown-it-mathjax/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-mathjax/interface.ts
+++ b/src/external-types/markdown-it-mathjax/interface.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-plantuml/index.d.ts
+++ b/src/external-types/markdown-it-plantuml/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-plantuml/interface.d.ts
+++ b/src/external-types/markdown-it-plantuml/interface.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-regex/index.d.ts
+++ b/src/external-types/markdown-it-regex/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-regex/interface.ts
+++ b/src/external-types/markdown-it-regex/interface.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-sub/index.d.ts
+++ b/src/external-types/markdown-it-sub/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-sup/index.d.ts
+++ b/src/external-types/markdown-it-sup/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/hooks/common/use-apply-dark-mode.ts
+++ b/src/hooks/common/use-apply-dark-mode.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/hooks/common/use-document-title.ts
+++ b/src/hooks/common/use-document-title.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/hooks/common/use-frontend-base-url.ts
+++ b/src/hooks/common/use-frontend-base-url.ts
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/hooks/common/use-is-dark-mode-activated.ts
+++ b/src/hooks/common/use-is-dark-mode-activated.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: AGPL-3.0-only
 */

--- a/src/links.json.license
+++ b/src/links.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/api-url/methods.ts
+++ b/src/redux/api-url/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/api-url/reducers.ts
+++ b/src/redux/api-url/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/api-url/types.ts
+++ b/src/redux/api-url/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/banner/methods.ts
+++ b/src/redux/banner/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/banner/reducers.ts
+++ b/src/redux/banner/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/banner/types.ts
+++ b/src/redux/banner/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/config/methods.ts
+++ b/src/redux/config/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/config/reducers.ts
+++ b/src/redux/config/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/config/types.ts
+++ b/src/redux/config/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/dark-mode/methods.ts
+++ b/src/redux/dark-mode/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/dark-mode/reducers.ts
+++ b/src/redux/dark-mode/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/dark-mode/types.ts
+++ b/src/redux/dark-mode/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/document-content/methods.ts
+++ b/src/redux/document-content/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/document-content/reducers.ts
+++ b/src/redux/document-content/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/document-content/types.ts
+++ b/src/redux/document-content/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/editor/methods.ts
+++ b/src/redux/editor/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/editor/reducers.ts
+++ b/src/redux/editor/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/editor/types.ts
+++ b/src/redux/editor/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/user/methods.ts
+++ b/src/redux/user/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/user/reducers.ts
+++ b/src/redux/user/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/user/types.ts
+++ b/src/redux/user/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/service-worker-registration.ts
+++ b/src/service-worker-registration.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/setup-tests.ts
+++ b/src/setup-tests.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_alert.scss
+++ b/src/style/bootstrap-color-theme/_alert.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_badge.scss
+++ b/src/style/bootstrap-color-theme/_badge.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_breadcrumb.scss
+++ b/src/style/bootstrap-color-theme/_breadcrumb.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_buttons.scss
+++ b/src/style/bootstrap-color-theme/_buttons.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_card.scss
+++ b/src/style/bootstrap-color-theme/_card.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_carousel.scss
+++ b/src/style/bootstrap-color-theme/_carousel.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_close.scss
+++ b/src/style/bootstrap-color-theme/_close.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_code.scss
+++ b/src/style/bootstrap-color-theme/_code.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_dropdown.scss
+++ b/src/style/bootstrap-color-theme/_dropdown.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_forms.scss
+++ b/src/style/bootstrap-color-theme/_forms.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_images.scss
+++ b/src/style/bootstrap-color-theme/_images.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_input-group.scss
+++ b/src/style/bootstrap-color-theme/_input-group.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_jumbotron.scss
+++ b/src/style/bootstrap-color-theme/_jumbotron.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_list-group.scss
+++ b/src/style/bootstrap-color-theme/_list-group.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_modal.scss
+++ b/src/style/bootstrap-color-theme/_modal.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_nav.scss
+++ b/src/style/bootstrap-color-theme/_nav.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_navbar.scss
+++ b/src/style/bootstrap-color-theme/_navbar.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_pagination.scss
+++ b/src/style/bootstrap-color-theme/_pagination.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_popover.scss
+++ b/src/style/bootstrap-color-theme/_popover.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_progress.scss
+++ b/src/style/bootstrap-color-theme/_progress.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_reboot.scss
+++ b/src/style/bootstrap-color-theme/_reboot.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_spinners.scss
+++ b/src/style/bootstrap-color-theme/_spinners.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_tables.scss
+++ b/src/style/bootstrap-color-theme/_tables.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_toasts.scss
+++ b/src/style/bootstrap-color-theme/_toasts.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_tooltip.scss
+++ b/src/style/bootstrap-color-theme/_tooltip.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/_type.scss
+++ b/src/style/bootstrap-color-theme/_type.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/include.scss
+++ b/src/style/bootstrap-color-theme/include.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/utilities/_background.scss
+++ b/src/style/bootstrap-color-theme/utilities/_background.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/utilities/_borders.scss
+++ b/src/style/bootstrap-color-theme/utilities/_borders.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/bootstrap-color-theme/utilities/_text.scss
+++ b/src/style/bootstrap-color-theme/utilities/_text.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/dark.scss
+++ b/src/style/dark.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/fonts/twemoji/twemoji.scss
+++ b/src/style/fonts/twemoji/twemoji.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/variables.dark.scss
+++ b/src/style/variables.dark.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/style/variables.light.scss
+++ b/src/style/variables.light.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/utils/is-test-mode.ts
+++ b/src/utils/is-test-mode.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/version.json.license
+++ b/src/version.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/tsconfig.json.license
+++ b/tsconfig.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/yarn.lock.license
+++ b/yarn.lock.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0


### PR DESCRIPTION
### Component/Part
Everything with our copyright notice

### Description
This PR changes the year in the copyright notice from 2020 to 2021

### Steps

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Additional Information

:tada:  Happy new year