### PR TITLE
added shortcut for addLink (ctrl+k)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,10 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 - Code blocks have a 'Copy code to clipboard' button.
 - Code blocks with 'vega-lite' as language are rendered as [vega-lite diagrams](https://vega.github.io/vega-lite/examples/).
 - Markdown files can be imported into an existing note directly from the editor.
-- The table button in the toolbar opens an overlay where the user can choose the number of columns and rows
+- The table button in the toolbar opens an overlay where the user can choose the number of columns and rows.
 - A toggle in the editor preferences for turning ligatures on and off.
 - Easier possibility to share notes via native share-buttons on supported devices.
+- Surround selected text with a link via shortcut (ctrl+k or cmd+k).
 
 ### Changed
 

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -195,6 +195,7 @@
                 "underline": "Underline selection",
                 "strikethrough": "Strike selection through",
                 "mark": "Mark selection",
+                "link": "Add link around selection",
                 "view": "Show only View",
                 "both": "Show View and Edit",
                 "edit": "Show only Edit"

--- a/src/components/editor/app-bar/help-button/shortcuts.tsx
+++ b/src/components/editor/app-bar/help-button/shortcuts.tsx
@@ -24,7 +24,8 @@ export const Shortcut: React.FC = () => {
       'editor.help.shortcuts.italic': [modifierKey, <> + </>, <kbd>I</kbd>],
       'editor.help.shortcuts.underline': [modifierKey, <> + </>, <kbd>U</kbd>],
       'editor.help.shortcuts.strikethrough': [modifierKey, <> + </>, <kbd>D</kbd>],
-      'editor.help.shortcuts.mark': [modifierKey, <> + </>, <kbd>M</kbd>]
+      'editor.help.shortcuts.mark': [modifierKey, <> + </>, <kbd>M</kbd>],
+      'editor.help.shortcuts.link': [modifierKey, <> + </>, <kbd>K</kbd>]
     }
   }
   return (

--- a/src/components/editor/editor-pane/key-map.ts
+++ b/src/components/editor/editor-pane/key-map.ts
@@ -7,6 +7,7 @@
 import CodeMirror, { Editor, KeyMap, Pass } from 'codemirror'
 import { isMac } from '../utils'
 import {
+  addLink,
   makeSelectionBold,
   makeSelectionItalic,
   markSelection,
@@ -81,7 +82,8 @@ export const defaultKeyMap: KeyMap = !isMac
       'Ctrl-B': makeSelectionBold,
       'Ctrl-U': underlineSelection,
       'Ctrl-D': strikeThroughSelection,
-      'Ctrl-M': markSelection
+      'Ctrl-M': markSelection,
+      'Ctrl-K': addLink
     }
   : {
       F9: suppressKey,


### PR DESCRIPTION
### Component/Part
editor

### Description
This PR adds a shortcut for the addLink functionality.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Extended changelog
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
fixes #858 
