### PR TITLE
Limit lightbox size

### DIFF
--- a/src/components/markdown-renderer/replace-components/image/lightbox.scss
+++ b/src/components/markdown-renderer/replace-components/image/lightbox.scss
@@ -1,0 +1,11 @@
+/*!
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+.lightbox img {
+  max-width: calc(100vw - 3.5rem);
+  max-height: calc(100vh - 3.5rem - 75px);
+  object-fit: contain;
+}

--- a/src/components/markdown-renderer/replace-components/image/lightboxedImageFrame.tsx
+++ b/src/components/markdown-renderer/replace-components/image/lightboxedImageFrame.tsx
@@ -7,6 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 import React, { Fragment, useState } from 'react'
 import { Modal } from 'react-bootstrap'
 import { ForkAwesomeIcon } from '../../../common/fork-awesome/fork-awesome-icon'
+import "./lightbox.scss"
 
 export const LightboxedImageFrame: React.FC<React.ImgHTMLAttributes<HTMLImageElement>> = ({ alt, ...props }) => {
   const [showFullscreenImage, setShowFullscreenImage] = useState(false)
@@ -17,7 +18,7 @@ export const LightboxedImageFrame: React.FC<React.ImgHTMLAttributes<HTMLImageEle
       <Modal
         animation={true}
         centered={true}
-        dialogClassName={'text-dark'}
+        dialogClassName={'text-dark lightbox'}
         show={showFullscreenImage}
         onHide={() => setShowFullscreenImage(false)}
         size={'xl'}>


### PR DESCRIPTION
### Component/Part
Image Lightbox

### Description
This PR limits the lightbox size to the screen size.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
