### PR TITLE
Add branch info to browserstack runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,6 +18,14 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v2
 
+      - name: Get branch and commit
+        id: gitinfo
+        run: |
+          if [ -n "${{ github.event.pull_request.head.sha }}" ]; \
+          then echo "::set-output name=shapr::$(echo ${{ github.event.pull_request.head.sha }} | cut -c -8) - #${{ github.event.pull_request.number }}"; \
+          else echo "::set-output name=shapr::$(echo ${{ github.sha }} | cut -c -8)"; fi
+          echo "::set-output name=branch::${GITHUB_HEAD_REF:-main}"
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -36,6 +44,9 @@ jobs:
         with:
           node-version: 14
 
+      - name: Install sponge utility
+        run: sudo apt-get install -yqq moreutils
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
 
@@ -44,6 +55,9 @@ jobs:
 
       - name: Start http server
         run: yarn serve:build &
+
+      - name: Set BrowserStack config values
+        run: jq '.run_settings.build_name = "${{ steps.gitinfo.outputs.shapr }} - ${{ steps.gitinfo.outputs.branch }}"' browserstack.json | sponge browserstack.json
 
       - name: Set up BrowserStack environment
         uses: 'browserstack/github-actions/setup-env@master'
@@ -57,10 +71,8 @@ jobs:
           local-testing: start
           local-identifier: random
 
-      - name: enable cypress videos
-        run: |
-          sudo apt-get install moreutils -yqq
-          jq '.video = true' cypress.json | sponge cypress.json
+      - name: Enable cypress videos
+        run: jq '.video = true' cypress.json | sponge cypress.json
 
       - name: Run BrowserStack Tests
         run: yarn run cy:browserstack

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,8 +22,8 @@ jobs:
         id: gitinfo
         run: |
           if [ -n "${{ github.event.pull_request.head.sha }}" ]; \
-          then echo "::set-output name=shapr::$(echo ${{ github.event.pull_request.head.sha }} | cut -c -8) - #${{ github.event.pull_request.number }}"; \
-          else echo "::set-output name=shapr::$(echo ${{ github.sha }} | cut -c -8)"; fi
+          then echo "::set-output name=shapr::$(echo ${{ github.event.pull_request.head.sha }} | cut -c -7) - #${{ github.event.pull_request.number }}"; \
+          else echo "::set-output name=shapr::$(echo ${{ github.sha }} | cut -c -7)"; fi
           echo "::set-output name=branch::${GITHUB_HEAD_REF:-main}"
 
       - name: Get yarn cache directory path

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 ![e2e](https://github.com/hedgedoc/react-client/workflows/e2e/badge.svg)
 ![lint](https://github.com/hedgedoc/react-client/workflows/lint/badge.svg)
 ![lint](https://github.com/hedgedoc/react-client/workflows/lint/badge.svg)
-[![BrowserStack Status](https://automate.browserstack.com/badge.svg?badge_key=UFp1ZTdJdHVMZTF2UEZCcmdZR1QwQzJSSVQyZHJMNFZQcVovRm5XbVVBWT0tLTNpWlFPV0hhai9vSzFTQ2xha3JzbVE9PQ==--b54f8953f94b792980183a46a302ebc15647f0ef)](https://automate.browserstack.com/public-build/UFp1ZTdJdHVMZTF2UEZCcmdZR1QwQzJSSVQyZHJMNFZQcVovRm5XbVVBWT0tLTNpWlFPV0hhai9vSzFTQ2xha3JzbVE9PQ==--b54f8953f94b792980183a46a302ebc15647f0ef)
 
 This is the new, improved and better looking frontend for HedgeDoc 2.0.
 Our goal is to recreate the current frontend in react and to improve it.

--- a/browserstack.json
+++ b/browserstack.json
@@ -18,8 +18,8 @@
     "run_settings": {
         "cypress_version": "6.2.0",
         "cypress_config_file": "./cypress.json",
-        "project_name": "HedgeDoc",
-        "build_name": "build-name",
+        "build_name": "",
+        "project_name": "hedgedoc/react-client",
         "exclude": [],
         "parallels": "5",
         "npm_dependencies": {


### PR DESCRIPTION
### Component/Part
GitHub actions workflows -> E2E browserstack

### Description
This PR adds branch information to the browserstack runs to easier identify them in the browserstack dashboard.

As @mrdrogdrog noted, the BrowserStack setup-env GitHub action has a field for build-name and project-name, but several commits (273772d, 928d312, 2f287b9, 4d53819, 216a90d, 7432e16, 09a39d8, 9ac28c4) showed they aren't working as expected.

Regarding the git commit sha extraction:
GitHub runs the tests in PRs against a simulated merge-commit with the base-branch. The commit SHA that is outputted by either git itself or by `${{github.sha}}` therefore is useless. Luckily GitHub provides the SHA of the commit that triggered a PR-run in a separate variable `${{github.event.pull_request.head.sha}}`. This variable isn't set on pushes to main, so I included a little if-else to use either the frist or the second variable.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
