### PR TITLE
Enable cypress video recording via environment variable

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,13 +57,10 @@ jobs:
           local-testing: start
           local-identifier: random
 
-      - name: enable cypress videos
-        run: |
-          sudo apt-get install moreutils -yqq
-          jq '.video = true' cypress.json | sponge cypress.json
-
       - name: Run BrowserStack Tests
         run: yarn run cy:browserstack
+        env:
+          CYPRESS_VIDEO_RECORDING: 1
 
       - name: Stop BrowserStack local connection
         uses: 'browserstack/github-actions/setup-local@master'


### PR DESCRIPTION
### Component/Part
Cypress in CI

### Description
This PR changes the CI configuration for cypress by enabling video recordings via environment instead of config.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
