### PR TITLE
Don't show "create table" overlay if modal is showing

### DIFF
--- a/src/components/editor/editor-pane/tool-bar/table-picker/table-picker.tsx
+++ b/src/components/editor/editor-pane/tool-bar/table-picker/table-picker.tsx
@@ -45,7 +45,7 @@ export const TablePicker: React.FC<TablePickerProps> = ({ show, onDismiss, onTab
   }, [onTablePicked, tableSize])
 
   return (
-    <div className={`position-absolute table-picker-container p-2 ${!show ? 'd-none' : ''} bg-light`} ref={containerRef} role="grid">
+    <div className={`position-absolute table-picker-container p-2 ${!show || showDialog ? 'd-none' : ''} bg-light`} ref={containerRef} role="grid">
       <p className={'lead'}>
         { tableSize
           ? t('editor.editorToolbar.table.size', { cols: tableSize?.columns, rows: tableSize.rows })


### PR DESCRIPTION
### Component/Part
"Insert table" overlay

### Description
This PR prevents, that the overlay and the modal are shown at the same time.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
