### PR TITLE
fixed title extraction to exclude latex code, but include rendered latex

### DIFF
--- a/cypress/integration/documentTitle.spec.ts
+++ b/cypress/integration/documentTitle.spec.ts
@@ -101,5 +101,13 @@ describe('Document Title', () => {
       cy.title()
         .should('eq', `${title} asd - HedgeDoc @ ${branding.name}`)
     })
+
+    it('katex code looks right', () => {
+      cy.get('a')
+        .get('@codeinput')
+        .fill(`# $\\alpha$-foo`)
+      cy.title()
+        .should('eq', `α-foo - HedgeDoc @ ${branding.name}`)
+    })
   })
 })

--- a/cypress/integration/documentTitle.spec.ts
+++ b/cypress/integration/documentTitle.spec.ts
@@ -95,16 +95,14 @@ describe('Document Title', () => {
     })
 
     it('markdown syntax removed third', () => {
-      cy.get('a')
-        .get('@codeinput')
+      cy.get('@codeinput')
         .fill(`# ${title} _asd_`)
       cy.title()
         .should('eq', `${title} asd - HedgeDoc @ ${branding.name}`)
     })
 
     it('katex code looks right', () => {
-      cy.get('a')
-        .get('@codeinput')
+      cy.get('@codeinput')
         .fill(`# $\\alpha$-foo`)
       cy.title()
         .should('eq', `α-foo - HedgeDoc @ ${branding.name}`)

--- a/cypress/integration/documentTitle.spec.ts
+++ b/cypress/integration/documentTitle.spec.ts
@@ -104,6 +104,10 @@ describe('Document Title', () => {
     it('katex code looks right', () => {
       cy.get('@codeinput')
         .fill(`# $\\alpha$-foo`)
+      cy.get('.markdown-body > h1')
+        .should('contain', 'α')
+      cy.get('@codeinput')
+        .type('\n\ntest\n')
       cy.title()
         .should('eq', `α-foo - HedgeDoc @ ${branding.name}`)
     })

--- a/src/components/markdown-renderer/hooks/use-extract-first-headline.ts
+++ b/src/components/markdown-renderer/hooks/use-extract-first-headline.ts
@@ -9,6 +9,11 @@ import React, { useCallback, useEffect } from 'react'
 export const useExtractFirstHeadline = (documentElement: React.RefObject<HTMLDivElement>, content: string, onFirstHeadingChange?: (firstHeading: string | undefined) => void): void => {
   const extractInnerText = useCallback((node: ChildNode): string => {
     let innerText = ''
+
+    if ((node as HTMLElement).classList?.contains("katex-mathml")) {
+      return ''
+    }
+
     if (node.childNodes && node.childNodes.length > 0) {
       node.childNodes.forEach((child) => { innerText += extractInnerText(child) })
     } else if (node.nodeName === 'IMG') {


### PR DESCRIPTION
### Component/Part
title extraction

### Description
This PR improves the title extraction to leave out latex code, but include latex output.
e.g
```
# $\alpha$-foo
```
puts `α-foo` as the title

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
concerns #815