### PR TITLE
Limit attributes for external links

### DIFF
--- a/src/components/markdown-renderer/replace-components/external-links-in-new-tabs/external-links-in-new-tabs.tsx
+++ b/src/components/markdown-renderer/replace-components/external-links-in-new-tabs/external-links-in-new-tabs.tsx
@@ -15,7 +15,7 @@ export class LinkInNewTabReplacer extends ComponentReplacer {
       return undefined
     }
 
-    return <a {...node.attribs} rel='noopener noreferrer' target='_blank'>
+    return <a className={node.attribs?.class} title={node.attribs?.title} href={node.attribs?.href} rel='noopener noreferrer' target='_blank'>
       {
         node.children?.map((child, index) => subNodeTransform(child, index))
       }


### PR DESCRIPTION
### Component/Part
Markdown renderer replacer for external links

### Description
This PR limits the attributes that are provided to external links in the external link replacer.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
