### PR TITLE
ABCFrame text-color is always black

### DIFF
--- a/src/components/markdown-renderer/replace-components/abc/abc-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/abc/abc-frame.tsx
@@ -24,5 +24,5 @@ export const AbcFrame: React.FC<AbcFrameProps> = ({ code }) => {
     }).catch(() => { console.error('error while loading abcjs') })
   }, [code])
 
-  return <div ref={container} className={'abcjs-score bg-white text-center overflow-x-auto'}/>
+  return <div ref={container} className={'abcjs-score bg-white text-black text-center overflow-x-auto'}/>
 }


### PR DESCRIPTION
### Component/Part
<!-- e.g markdown editor -->

### Description
This PR sets the text-color of ABCFrame to always be black 

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
fixes #977
