### PR TITLE
change domain in build:serve script

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "start": "cross-env PORT=3001 craco start",
         "start:test": "cross-env PORT=3001 REACT_APP_TEST_MODE=true craco start",
         "start:for-real-backend": "cross-env REACT_APP_BACKEND=http://localhost:3000 yarn start",
-        "serve:build": "http-server build/ -s -p 3001 -P \"http://127.0.0.1:3001?\"",
+        "serve:build": "http-server build/ -s -p 3001 -P \"http://localhost:3001?\"",
         "build:test": "cross-env REACT_APP_TEST_MODE=true craco build",
         "build:production": "craco build",
         "analyze": "cross-env ANALYZE=true craco build",


### PR DESCRIPTION
### Component/Part
<!-- e.g markdown editor -->

### Description
This PR fixes under which domain the serve:build script runs the frontend.

This makes the iframe work in this mode

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.