### PR TITLE
Include markmap-common in renovate group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,7 +41,8 @@
       "groupName": "markmap",
       "packagePatterns": [
         "markmap-view",
-        "markmap-lib"
+        "markmap-lib",
+        "markmap-common"
       ]
     },
     {


### PR DESCRIPTION
### Component/Part
Renovate

### Description
This PR adds `markmap-common` to the `markmap` group

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
#993 #994
