### PR TITLE
Remove custom abcjs types

### DIFF
--- a/src/components/markdown-renderer/replace-components/abc/abc-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/abc/abc-frame.tsx
@@ -19,12 +19,13 @@ export const AbcFrame: React.FC<AbcFrameProps> = ({ code }) => {
       return
     }
     const actualContainer = container.current
-    import(/* webpackChunkName: "abc.js" */ 'abcjs').then((imp) => {
-      imp.renderAbc(actualContainer, code)
-    })
-                                                    .catch(() => {
-                                                      console.error('error while loading abcjs')
-                                                    })
+    import(/* webpackChunkName: "abc.js" */ 'abcjs')
+      .then((imp) => {
+        imp.renderAbc(actualContainer, code, {})
+      })
+      .catch(() => {
+        console.error('error while loading abcjs')
+      })
   }, [code])
 
   return <div ref={ container } className={ 'abcjs-score bg-white text-black text-center overflow-x-auto' }/>

--- a/src/external-types/abcjs/abcjs.d.ts
+++ b/src/external-types/abcjs/abcjs.d.ts
@@ -1,9 +1,0 @@
-/*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
- *
- * SPDX-License-Identifier: AGPL-3.0-only
- */
-
-declare module 'abcjs' {
-  export function renderAbc(target: string | HTMLElement, code: string)
-}


### PR DESCRIPTION
### Component/Part
ABC.js rendering

### Description
This PR removes our custom types for ABC.js, because they are included into the upstream package.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
