### PR TITLE
Add e2e tests for diagrams and embeddings

### DIFF
--- a/cypress/integration/diagrams.spec.ts
+++ b/cypress/integration/diagrams.spec.ts
@@ -62,6 +62,7 @@ describe('Diagram codeblock gets rendered: ', () => {
     cy.codemirrorFill('```plantuml\nclass Example\n```')
     cy.getMarkdownBody()
       .find('img')
-      .should('have.attr', 'title', 'uml diagram')
+      // PlantUML uses base64 encoded version of zip-deflated PlantUML code in the request URL.
+      .should('have.attr', 'src', 'http://mock-plantuml.local/svg/SoWkIImgAStDuKhEIImkLd2jICmjo4dbSaZDIm6A0W00')
   })
 })

--- a/cypress/integration/diagrams.spec.ts
+++ b/cypress/integration/diagrams.spec.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-describe('Diagram codeblock gets rendered: ', () => {
+describe('Diagram codeblock ', () => {
   beforeEach(() => {
     cy.visitTestEditor()
   })
 
-  it('markmap', () => {
+  it('renders markmap', () => {
     cy.codemirrorFill('```markmap\n- pro\n- contra\n```')
     cy.getMarkdownBody()
       .find('[data-cy=markmap]')
@@ -17,7 +17,7 @@ describe('Diagram codeblock gets rendered: ', () => {
       .should('be.visible')
   })
 
-  it('vega-lite', () => {
+  it('renders vega-lite', () => {
     cy.codemirrorFill('```vega-lite\n{"$schema":"https://vega.github.io/schema/vega-lite/v4.json","data":{"values":[{"a":"","b":28}]},"mark":"bar","encoding":{"x":{"field":"a"},"y":{"field":"b"}}}\n```')
     cy.getMarkdownBody()
       .find('.vega-embed')
@@ -25,7 +25,7 @@ describe('Diagram codeblock gets rendered: ', () => {
       .should('be.visible')
   })
 
-  it('graphviz', () => {
+  it('renders graphviz', () => {
     cy.codemirrorFill('```graphviz\ngraph {\na -- b\n}\n```')
     cy.getMarkdownBody()
       .find('[data-cy=graphviz]')
@@ -33,7 +33,7 @@ describe('Diagram codeblock gets rendered: ', () => {
       .should('be.visible')
   })
 
-  it('mermaid', () => {
+  it('renders mermaid', () => {
     cy.codemirrorFill('```mermaid\ngraph TD;\n    A-->B;\n```')
     cy.getMarkdownBody()
       .find('.mermaid')
@@ -41,7 +41,7 @@ describe('Diagram codeblock gets rendered: ', () => {
       .should('be.visible')
   })
 
-  it('flowchart', () => {
+  it('renders flowcharts', () => {
     cy.codemirrorFill('```flow\nst=>start: Start\ne=>end: End\nst->e\n```')
     cy.getMarkdownBody()
       .find('[data-cy=flowchart]')
@@ -49,7 +49,7 @@ describe('Diagram codeblock gets rendered: ', () => {
       .should('be.visible')
   })
 
-  it('abc', () => {
+  it('renders abc scores', () => {
     cy.codemirrorFill('```abc\nM:4/4\nK:G\n|:GABc dedB:|\n```')
     cy.getMarkdownBody()
       .find('.abcjs-score')
@@ -57,14 +57,14 @@ describe('Diagram codeblock gets rendered: ', () => {
       .should('be.visible')
   })
 
-  it('csv', () => {
+  it('renders csv as table', () => {
     cy.codemirrorFill('```csv delimiter=; header\na;b;c;d\n1;2;3;4\n```')
     cy.getMarkdownBody()
       .find('.csv-html-table')
       .should('be.visible')
   })
 
-  it('plantuml', () => {
+  it('renders plantuml', () => {
     cy.codemirrorFill('```plantuml\nclass Example\n```')
     cy.getMarkdownBody()
       .find('img')

--- a/cypress/integration/diagrams.spec.ts
+++ b/cypress/integration/diagrams.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+describe('renders diagram', () => {
+  beforeEach(() => {
+    cy.visitTestEditor()
+  })
+
+  it('markmap', () => {
+    cy.codemirrorFill('```markmap\n- pro\n- contra\n```')
+    cy.getMarkdownBody()
+      .find('svg')
+      .should('be.visible')
+  })
+
+  it('vega-lite', () => {
+    cy.codemirrorFill('```vega-lite\n{"$schema":"https://vega.github.io/schema/vega-lite/v4.json","data":{"values":[{"a":"","b":28}]},"mark":"bar","encoding":{"x":{"field":"a"},"y":{"field":"b"}}}\n```')
+    cy.getMarkdownBody()
+      .find('div.vega-embed canvas')
+      .should('be.visible')
+  })
+
+  it('graphviz', () => {
+    cy.codemirrorFill('```graphviz\ngraph {\na -- b\n}\n```')
+    cy.getMarkdownBody()
+      .find('svg')
+      .should('be.visible')
+  })
+
+  it('mermaid', () => {
+    cy.codemirrorFill('```mermaid\ngraph TD;\n    A-->B;\n```')
+    cy.getMarkdownBody()
+      .find('div.mermaid > svg')
+      .should('be.visible')
+  })
+
+  it('flowchart', () => {
+    cy.codemirrorFill('```flow\nst=>start: Start\ne=>end: End\nst->e\n```')
+    cy.getMarkdownBody()
+      .find('svg')
+      .should('be.visible')
+  })
+
+  it('abc', () => {
+    cy.codemirrorFill('```abc\nM:4/4\nK:G\n|:GABc dedB:|\n```')
+    cy.getMarkdownBody()
+      .find('div.abcjs-score > svg')
+      .should('be.visible')
+  })
+
+  it('csv', () => {
+    cy.codemirrorFill('```csv delimiter=; header\na;b;c;d\n1;2;3;4\n```')
+    cy.getMarkdownBody()
+      .find('table.csv-html-table')
+      .should('be.visible')
+  })
+
+  it('plantuml', () => {
+    cy.codemirrorFill('```plantuml\nclass Example\n```')
+    cy.getMarkdownBody()
+      .find('img')
+      .should('have.attr', 'title', 'uml diagram')
+  })
+})

--- a/cypress/integration/diagrams.spec.ts
+++ b/cypress/integration/diagrams.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-describe('renders diagram', () => {
+describe('Diagram codeblock gets rendered: ', () => {
   beforeEach(() => {
     cy.visitTestEditor()
   })
@@ -12,7 +12,7 @@ describe('renders diagram', () => {
   it('markmap', () => {
     cy.codemirrorFill('```markmap\n- pro\n- contra\n```')
     cy.getMarkdownBody()
-      .find('svg')
+      .find('div[data-cy=markmap] svg')
       .should('be.visible')
   })
 
@@ -26,7 +26,7 @@ describe('renders diagram', () => {
   it('graphviz', () => {
     cy.codemirrorFill('```graphviz\ngraph {\na -- b\n}\n```')
     cy.getMarkdownBody()
-      .find('svg')
+      .find('div[data-cy=graphviz] svg')
       .should('be.visible')
   })
 
@@ -40,7 +40,7 @@ describe('renders diagram', () => {
   it('flowchart', () => {
     cy.codemirrorFill('```flow\nst=>start: Start\ne=>end: End\nst->e\n```')
     cy.getMarkdownBody()
-      .find('svg')
+      .find('div[data-cy=flowchart] svg')
       .should('be.visible')
   })
 
@@ -54,7 +54,7 @@ describe('renders diagram', () => {
   it('csv', () => {
     cy.codemirrorFill('```csv delimiter=; header\na;b;c;d\n1;2;3;4\n```')
     cy.getMarkdownBody()
-      .find('table.csv-html-table')
+      .find('.csv-html-table')
       .should('be.visible')
   })
 

--- a/cypress/integration/diagrams.spec.ts
+++ b/cypress/integration/diagrams.spec.ts
@@ -12,42 +12,48 @@ describe('Diagram codeblock gets rendered: ', () => {
   it('markmap', () => {
     cy.codemirrorFill('```markmap\n- pro\n- contra\n```')
     cy.getMarkdownBody()
-      .find('[data-cy=markmap] svg')
+      .find('[data-cy=markmap]')
+      .children()
       .should('be.visible')
   })
 
   it('vega-lite', () => {
     cy.codemirrorFill('```vega-lite\n{"$schema":"https://vega.github.io/schema/vega-lite/v4.json","data":{"values":[{"a":"","b":28}]},"mark":"bar","encoding":{"x":{"field":"a"},"y":{"field":"b"}}}\n```')
     cy.getMarkdownBody()
-      .find('.vega-embed canvas')
+      .find('.vega-embed')
+      .children()
       .should('be.visible')
   })
 
   it('graphviz', () => {
     cy.codemirrorFill('```graphviz\ngraph {\na -- b\n}\n```')
     cy.getMarkdownBody()
-      .find('[data-cy=graphviz] svg')
+      .find('[data-cy=graphviz]')
+      .children()
       .should('be.visible')
   })
 
   it('mermaid', () => {
     cy.codemirrorFill('```mermaid\ngraph TD;\n    A-->B;\n```')
     cy.getMarkdownBody()
-      .find('.mermaid > svg')
+      .find('.mermaid')
+      .children()
       .should('be.visible')
   })
 
   it('flowchart', () => {
     cy.codemirrorFill('```flow\nst=>start: Start\ne=>end: End\nst->e\n```')
     cy.getMarkdownBody()
-      .find('[data-cy=flowchart] svg')
+      .find('[data-cy=flowchart]')
+      .children()
       .should('be.visible')
   })
 
   it('abc', () => {
     cy.codemirrorFill('```abc\nM:4/4\nK:G\n|:GABc dedB:|\n```')
     cy.getMarkdownBody()
-      .find('.abcjs-score > svg')
+      .find('.abcjs-score')
+      .children()
       .should('be.visible')
   })
 

--- a/cypress/integration/diagrams.spec.ts
+++ b/cypress/integration/diagrams.spec.ts
@@ -12,42 +12,42 @@ describe('Diagram codeblock gets rendered: ', () => {
   it('markmap', () => {
     cy.codemirrorFill('```markmap\n- pro\n- contra\n```')
     cy.getMarkdownBody()
-      .find('div[data-cy=markmap] svg')
+      .find('[data-cy=markmap] svg')
       .should('be.visible')
   })
 
   it('vega-lite', () => {
     cy.codemirrorFill('```vega-lite\n{"$schema":"https://vega.github.io/schema/vega-lite/v4.json","data":{"values":[{"a":"","b":28}]},"mark":"bar","encoding":{"x":{"field":"a"},"y":{"field":"b"}}}\n```')
     cy.getMarkdownBody()
-      .find('div.vega-embed canvas')
+      .find('.vega-embed canvas')
       .should('be.visible')
   })
 
   it('graphviz', () => {
     cy.codemirrorFill('```graphviz\ngraph {\na -- b\n}\n```')
     cy.getMarkdownBody()
-      .find('div[data-cy=graphviz] svg')
+      .find('[data-cy=graphviz] svg')
       .should('be.visible')
   })
 
   it('mermaid', () => {
     cy.codemirrorFill('```mermaid\ngraph TD;\n    A-->B;\n```')
     cy.getMarkdownBody()
-      .find('div.mermaid > svg')
+      .find('.mermaid > svg')
       .should('be.visible')
   })
 
   it('flowchart', () => {
     cy.codemirrorFill('```flow\nst=>start: Start\ne=>end: End\nst->e\n```')
     cy.getMarkdownBody()
-      .find('div[data-cy=flowchart] svg')
+      .find('[data-cy=flowchart] svg')
       .should('be.visible')
   })
 
   it('abc', () => {
     cy.codemirrorFill('```abc\nM:4/4\nK:G\n|:GABc dedB:|\n```')
     cy.getMarkdownBody()
-      .find('div.abcjs-score > svg')
+      .find('.abcjs-score > svg')
       .should('be.visible')
   })
 

--- a/cypress/integration/linkEmbedder.spec.ts
+++ b/cypress/integration/linkEmbedder.spec.ts
@@ -15,8 +15,8 @@ describe('Link gets replaced with embedding: ', () => {
       .find('.one-click-embedding.gist-frame')
       .click()
     cy.getMarkdownBody()
-      .find('iframe')
-      .should('have.attr', 'title', 'gist schacon/1')
+      .find('iframe[data-cy=gh-gist]')
+      .should('be.visible')
   })
 
   it('YouTube', () => {

--- a/cypress/integration/linkEmbedder.spec.ts
+++ b/cypress/integration/linkEmbedder.spec.ts
@@ -9,6 +9,8 @@ describe('Link gets replaced with embedding: ', () => {
     cy.visitTestEditor()
   })
 
+  // TODO Add general testing of one-click-embedding component. The tests below just test a specific use of the component.
+
   it('GitHub Gist', () => {
     cy.codemirrorFill('https://gist.github.com/schacon/1')
     cy.getMarkdownBody()

--- a/cypress/integration/linkEmbedder.spec.ts
+++ b/cypress/integration/linkEmbedder.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-describe('links to embeddable content', () => {
+describe('Link gets replaced with embedding: ', () => {
   beforeEach(() => {
     cy.visitTestEditor()
   })
@@ -12,7 +12,7 @@ describe('links to embeddable content', () => {
   it('GitHub Gist', () => {
     cy.codemirrorFill('https://gist.github.com/schacon/1')
     cy.getMarkdownBody()
-      .find('span.one-click-embedding.gist-frame')
+      .find('.one-click-embedding.gist-frame')
       .click()
     cy.getMarkdownBody()
       .find('iframe')
@@ -22,7 +22,7 @@ describe('links to embeddable content', () => {
   it('YouTube', () => {
     cy.codemirrorFill('https://www.youtube.com/watch?v=YE7VzlLtp-4')
     cy.getMarkdownBody()
-      .find('span.one-click-embedding.embed-responsive-item')
+      .find('.one-click-embedding.embed-responsive-item')
       .click()
     cy.getMarkdownBody()
       .find('iframe')
@@ -32,7 +32,7 @@ describe('links to embeddable content', () => {
   it('Vimeo', () => {
     cy.codemirrorFill('https://vimeo.com/23237102')
     cy.getMarkdownBody()
-      .find('span.one-click-embedding.embed-responsive-item')
+      .find('.one-click-embedding.embed-responsive-item')
       .click()
     cy.getMarkdownBody()
       .find('iframe')
@@ -42,7 +42,7 @@ describe('links to embeddable content', () => {
   it('Asciinema', () => {
     cy.codemirrorFill('https://asciinema.org/a/117928')
     cy.getMarkdownBody()
-      .find('span.one-click-embedding.embed-responsive-item')
+      .find('.one-click-embedding.embed-responsive-item')
       .click()
     cy.getMarkdownBody()
       .find('iframe')

--- a/cypress/integration/linkEmbedder.spec.ts
+++ b/cypress/integration/linkEmbedder.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+describe('links to embeddable content', () => {
+  beforeEach(() => {
+    cy.visitTestEditor()
+  })
+
+  it('GitHub Gist', () => {
+    cy.codemirrorFill('https://gist.github.com/schacon/1')
+    cy.getMarkdownBody()
+      .find('span.one-click-embedding.gist-frame')
+      .click()
+    cy.getMarkdownBody()
+      .find('iframe')
+      .should('have.attr', 'title', 'gist schacon/1')
+  })
+
+  it('YouTube', () => {
+    cy.codemirrorFill('https://www.youtube.com/watch?v=YE7VzlLtp-4')
+    cy.getMarkdownBody()
+      .find('span.one-click-embedding.embed-responsive-item')
+      .click()
+    cy.getMarkdownBody()
+      .find('iframe')
+      .should('have.attr', 'src', 'https://www.youtube-nocookie.com/embed/YE7VzlLtp-4?autoplay=1')
+  })
+
+  it('Vimeo', () => {
+    cy.codemirrorFill('https://vimeo.com/23237102')
+    cy.getMarkdownBody()
+      .find('span.one-click-embedding.embed-responsive-item')
+      .click()
+    cy.getMarkdownBody()
+      .find('iframe')
+      .should('have.attr', 'src', 'https://player.vimeo.com/video/23237102?autoplay=1')
+  })
+
+  it('Asciinema', () => {
+    cy.codemirrorFill('https://asciinema.org/a/117928')
+    cy.getMarkdownBody()
+      .find('span.one-click-embedding.embed-responsive-item')
+      .click()
+    cy.getMarkdownBody()
+      .find('iframe')
+      .should('have.attr', 'src', 'https://asciinema.org/a/117928/embed?autoplay=1')
+  })
+})

--- a/cypress/integration/linkEmbedder.spec.ts
+++ b/cypress/integration/linkEmbedder.spec.ts
@@ -22,7 +22,9 @@ describe('Link gets replaced with embedding: ', () => {
   it('YouTube', () => {
     cy.codemirrorFill('https://www.youtube.com/watch?v=YE7VzlLtp-4')
     cy.getMarkdownBody()
-      .find('.one-click-embedding.embed-responsive-item')
+      .find('.one-click-embedding-preview')
+      .should('have.attr', 'src', 'https://i.ytimg.com/vi/YE7VzlLtp-4/maxresdefault.jpg')
+      .parent()
       .click()
     cy.getMarkdownBody()
       .find('iframe')
@@ -30,9 +32,21 @@ describe('Link gets replaced with embedding: ', () => {
   })
 
   it('Vimeo', () => {
+    cy.intercept({
+      method: 'GET',
+      url: 'https://vimeo.com/api/v2/video/23237102.json'
+    }, {
+      statusCode: 200,
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: '[{"thumbnail_large": "https://i.vimeocdn.com/video/503631401_640.jpg"}]'
+    })
     cy.codemirrorFill('https://vimeo.com/23237102')
     cy.getMarkdownBody()
-      .find('.one-click-embedding.embed-responsive-item')
+      .find('.one-click-embedding-preview')
+      .should('have.attr', 'src', 'https://i.vimeocdn.com/video/503631401_640.jpg')
+      .parent()
       .click()
     cy.getMarkdownBody()
       .find('iframe')
@@ -42,7 +56,9 @@ describe('Link gets replaced with embedding: ', () => {
   it('Asciinema', () => {
     cy.codemirrorFill('https://asciinema.org/a/117928')
     cy.getMarkdownBody()
-      .find('.one-click-embedding.embed-responsive-item')
+      .find('.one-click-embedding-preview')
+      .should('have.attr', 'src', 'https://asciinema.org/a/117928.png')
+      .parent()
       .click()
     cy.getMarkdownBody()
       .find('iframe')

--- a/cypress/integration/shortcodes.spec.ts
+++ b/cypress/integration/shortcodes.spec.ts
@@ -17,4 +17,13 @@ describe('Short code', () => {
         .should('have.attr', 'href', 'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf')
     })
   })
+
+  describe('slideshare', () => {
+    it('renders a plain link', () => {
+      cy.codemirrorFill(`{%slideshare example/123456789 %}`)
+      cy.getMarkdownBody()
+        .find('a')
+        .should('have.attr', 'href', 'https://www.slideshare.net/example/123456789')
+    })
+  })
 })

--- a/cypress/integration/shortcodes.spec.ts
+++ b/cypress/integration/shortcodes.spec.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-describe('Short code', () => {
+describe('Short code gets replaced or rendered: ', () => {
   beforeEach(() => {
     cy.visitTestEditor()
   })
 
-  describe('for pdfs', () => {
+  describe('pdf', () => {
     it('renders a plain link', () => {
       cy.codemirrorFill(`{%pdf https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf %}`)
       cy.getMarkdownBody()
@@ -24,6 +24,23 @@ describe('Short code', () => {
       cy.getMarkdownBody()
         .find('a')
         .should('have.attr', 'href', 'https://www.slideshare.net/example/123456789')
+    })
+  })
+
+  describe('speakerdeck', () => {
+    it('renders a plain link', () => {
+      cy.codemirrorFill(`{%speakerdeck example/123456789 %}`)
+      cy.getMarkdownBody()
+        .find('a')
+        .should('have.attr', 'href', 'https://speakerdeck.com/example/123456789')
+    })
+  })
+
+  describe('youtube', () => {
+    it('renders one-click-embedding', () => {
+      cy.codemirrorFill(`{%youtube YE7VzlLtp-4 %}`)
+      cy.getMarkdownBody()
+        .find('.one-click-embedding.embed-responsive-item')
     })
   })
 })

--- a/cypress/support/config.ts
+++ b/cypress/support/config.ts
@@ -45,6 +45,7 @@ beforeEach(() => {
         termsOfUse: 'https://example.com/termsOfUse',
         imprint: 'https://example.com/imprint'
       },
+      plantumlServer: 'http://www.plantuml.com/plantuml',
       version: {
         version: 'mock',
         sourceCodeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',

--- a/cypress/support/config.ts
+++ b/cypress/support/config.ts
@@ -45,7 +45,7 @@ beforeEach(() => {
         termsOfUse: 'https://example.com/termsOfUse',
         imprint: 'https://example.com/imprint'
       },
-      plantumlServer: 'http://www.plantuml.com/plantuml',
+      plantumlServer: 'http://mock-plantuml.local',
       version: {
         version: 'mock',
         sourceCodeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',

--- a/src/components/markdown-renderer/replace-components/flow/flowchart/flowchart.tsx
+++ b/src/components/markdown-renderer/replace-components/flow/flowchart/flowchart.tsx
@@ -58,6 +58,6 @@ export const FlowChart: React.FC<FlowChartProps> = ({ code }) => {
         <Trans i18nKey={ 'renderer.flowchart.invalidSyntax' }/>
       </Alert>)
   } else {
-    return <div ref={ diagramRef } className={ 'text-center' }/>
+    return <div ref={ diagramRef } data-cy={ 'flowchart' } className={ 'text-center' }/>
   }
 }

--- a/src/components/markdown-renderer/replace-components/gist/gist-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/gist/gist-frame.tsx
@@ -66,6 +66,7 @@ export const GistFrame: React.FC<GistFrameProps> = ({ id }) => {
   return (
     <iframe
       sandbox="allow-scripts allow-top-navigation-by-user-activation allow-popups"
+      data-cy={ 'gh-gist' }
       width='100%'
       height={ `${ frameHeight }px` }
       frameBorder='0'

--- a/src/components/markdown-renderer/replace-components/graphviz/graphviz-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/graphviz/graphviz-frame.tsx
@@ -55,12 +55,14 @@ export const GraphvizFrame: React.FC<GraphvizFrameProps> = ({ code }) => {
       })
   }, [code, error, showError])
 
-  return <Fragment>
-    <ShowIf condition={ !!error }>
-      <Alert variant={ 'warning' }>{ error }</Alert>
-    </ShowIf>
-    <div className={ 'text-center overflow-x-auto' } ref={ container }/>
-  </Fragment>
+  return (
+    <Fragment>
+      <ShowIf condition={ !!error }>
+        <Alert variant={ 'warning' }>{ error }</Alert>
+      </ShowIf>
+      <div className={ 'text-center overflow-x-auto' } data-cy={ 'graphviz' } ref={ container }/>
+    </Fragment>
+  )
 }
 
 export default GraphvizFrame

--- a/src/components/markdown-renderer/replace-components/markmap/markmap-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/markmap/markmap-frame.tsx
@@ -63,12 +63,12 @@ export const MarkmapFrame: React.FC<MarkmapFrameProps> = ({ code }) => {
   }, [code])
 
   return (
-    <Fragment>
+    <div data-cy={ 'markmap' }>
       <div className={ 'text-center' } ref={ diagramContainer }/>
       <div className={ 'text-right button-inside' }>
         <LockButton locked={ disablePanAndZoom } onLockedChanged={ (newState => setDisablePanAndZoom(newState)) }
                     title={ disablePanAndZoom ? t('renderer.markmap.locked') : t('renderer.markmap.unlocked') }/>
       </div>
-    </Fragment>
+    </div>
   )
 }

--- a/src/components/markdown-renderer/replace-components/markmap/markmap-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/markmap/markmap-frame.tsx
@@ -4,7 +4,7 @@
  SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React, { Fragment, useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LockButton } from '../../../common/lock-button/lock-button'
 import '../../utils/button-inside.scss'

--- a/src/components/markdown-renderer/replace-components/youtube/youtube-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/youtube/youtube-frame.tsx
@@ -15,7 +15,7 @@ export const YouTubeFrame: React.FC<YouTubeFrameProps> = ({ id }) => {
   return (
     <OneClickEmbedding containerClassName={ 'embed-responsive embed-responsive-16by9' }
                        previewContainerClassName={ 'embed-responsive-item' } hoverIcon={ 'youtube-play' }
-                       loadingImageUrl={ `//i.ytimg.com/vi/${ id }/maxresdefault.jpg` }>
+                       loadingImageUrl={ `https://i.ytimg.com/vi/${ id }/maxresdefault.jpg` }>
       <iframe className='embed-responsive-item' title={ `youtube video of ${ id }` }
               src={ `https://www.youtube-nocookie.com/embed/${ id }?autoplay=1` }
               allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"/>

--- a/src/components/markdown-renderer/replace-components/youtube/youtube-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/youtube/youtube-frame.tsx
@@ -17,7 +17,7 @@ export const YouTubeFrame: React.FC<YouTubeFrameProps> = ({ id }) => {
                        previewContainerClassName={ 'embed-responsive-item' } hoverIcon={ 'youtube-play' }
                        loadingImageUrl={ `//i.ytimg.com/vi/${ id }/maxresdefault.jpg` }>
       <iframe className='embed-responsive-item' title={ `youtube video of ${ id }` }
-              src={ `//www.youtube-nocookie.com/embed/${ id }?autoplay=1` }
+              src={ `https://www.youtube-nocookie.com/embed/${ id }?autoplay=1` }
               allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"/>
     </OneClickEmbedding>
   )


### PR DESCRIPTION
### Component/Part
E2E tests

### Description
This PR adds e2e tests for diagrams and embeddings. As most of the diagrams only yield a `svg` element into the DOM, the tests can ensure that some svg element is visible, but can't ensure that it really belongs to the tested diagram.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
Closes #1022 
