### PR TITLE
Don't show i18n messages in production mode

### DIFF
--- a/src/components/application-loader/initializers/i18n.ts
+++ b/src/components/application-loader/initializers/i18n.ts
@@ -17,13 +17,13 @@ export const setUpI18n = async (): Promise<void> => {
     .use(initReactI18next)
     .init({
       fallbackLng: 'en',
-      debug: true,
+      debug: process.env.NODE_ENV !== 'production',
       backend: {
         loadPath: '/locales/{{lng}}.json'
       },
 
       interpolation: {
-        escapeValue: false // not needed for react as it escapes by default
+        escapeValue: false
       }
     })
 


### PR DESCRIPTION
### Component/Part
i18n configuration

### Description
i18n spams its debug messages into the console. This PR disables this behaviour in production mode.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
