### PR TITLE
Add one-click login if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,8 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 - The dark-mode is also applied to the read-only-view and can be toggled from there.
 - Access tokens for the CLI and 3rd-party-clients can be managed in the user profile.
 - Change editor font to "Fira Code"
-- Note tags can be set as yaml-array in frontmatter
+- Note tags can be set as yaml-array in frontmatter.
+- If only one external login provider is configured, the sign-in button will directly link to it.
 
 ---
 

--- a/cypress/integration/autocompletion.spec.ts
+++ b/cypress/integration/autocompletion.spec.ts
@@ -6,6 +6,7 @@
 
 describe('Autocompletion', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.visitTestEditor()
     cy.get('.CodeMirror')
       .click()

--- a/cypress/integration/banner.spec.ts
+++ b/cypress/integration/banner.spec.ts
@@ -8,6 +8,7 @@ import { banner } from '../support/config'
 
 describe('Banner', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.visit('/')
     expect(localStorage.getItem('bannerTimeStamp')).to.be.null
   })

--- a/cypress/integration/diagrams.spec.ts
+++ b/cypress/integration/diagrams.spec.ts
@@ -6,6 +6,7 @@
 
 describe('Diagram codeblock ', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.visitTestEditor()
   })
 

--- a/cypress/integration/documentTitle.spec.ts
+++ b/cypress/integration/documentTitle.spec.ts
@@ -9,6 +9,7 @@ import { branding } from '../support/config'
 const title = 'This is a test title'
 describe('Document Title', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.visitTestEditor()
     cy.get('.btn.active.btn-outline-secondary > i.fa-columns')
       .should('exist')

--- a/cypress/integration/editorMode.spec.ts
+++ b/cypress/integration/editorMode.spec.ts
@@ -5,6 +5,10 @@
  */
 
 describe('Editor mode from URL parameter is used', () => {
+  beforeEach(() => {
+    cy.loadConfig()
+  })
+
   it('mode view', () => {
     cy.visitTestEditor('view')
     cy.get('.splitter.left')

--- a/cypress/integration/export.spec.ts
+++ b/cypress/integration/export.spec.ts
@@ -9,6 +9,7 @@ describe('Export', () => {
   const testContent = `---\ntitle: ${ testTitle }\n---\nThis is some test content`
 
   beforeEach(() => {
+    cy.loadConfig()
     cy.visitTestEditor()
     cy.codemirrorFill(testContent)
   })

--- a/cypress/integration/fileUpload.spec.ts
+++ b/cypress/integration/fileUpload.spec.ts
@@ -8,6 +8,7 @@ const imageUrl = 'http://example.com/non-existing.png'
 
 describe('File upload', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.visitTestEditor()
   })
 

--- a/cypress/integration/helpDialog.spec.ts
+++ b/cypress/integration/helpDialog.spec.ts
@@ -6,6 +6,7 @@
 
 describe('Help Dialog', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.visitTestEditor()
   })
 

--- a/cypress/integration/highlightedCodeBlock.spec.ts
+++ b/cypress/integration/highlightedCodeBlock.spec.ts
@@ -12,6 +12,7 @@ const findHljsCodeBlock = () => {
 
 describe('Code', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.visitTestEditor()
   })
 

--- a/cypress/integration/history.spec.ts
+++ b/cypress/integration/history.spec.ts
@@ -6,6 +6,7 @@
 
 describe('History', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.visit('/history')
   })
 

--- a/cypress/integration/import.spec.ts
+++ b/cypress/integration/import.spec.ts
@@ -6,6 +6,7 @@
 
 describe('Import markdown file', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.visitTestEditor()
   })
 

--- a/cypress/integration/intro.spec.ts
+++ b/cypress/integration/intro.spec.ts
@@ -7,6 +7,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 describe('Intro page', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.intercept('/intro.md', 'test content')
     cy.visit('/')
   })

--- a/cypress/integration/language.spec.ts
+++ b/cypress/integration/language.spec.ts
@@ -8,6 +8,7 @@ import { languages } from '../fixtures/languages'
 
 describe('Languages', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.visit('/')
   })
 

--- a/cypress/integration/link.spec.ts
+++ b/cypress/integration/link.spec.ts
@@ -8,6 +8,7 @@ import '../support/index'
 
 describe('Links Intro', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.visit('/')
   })
 

--- a/cypress/integration/link.spec.ts
+++ b/cypress/integration/link.spec.ts
@@ -53,13 +53,6 @@ describe('Links Intro', () => {
       cy.url()
         .should('include', '/new')
     })
-
-    it('Sign In', () => {
-      cy.get('.btn-success.btn-sm')
-        .click()
-      cy.url()
-        .should('include', '/login')
-    })
   })
 
   describe('Menu Buttons logged in', () => {
@@ -83,7 +76,7 @@ describe('Links Intro', () => {
           .should('include', '/features')
       })
 
-      it('Features', () => {
+      it('Profile', () => {
         cy.get('a.dropdown-item > i.fa-user')
           .click()
         cy.url()

--- a/cypress/integration/linkEmbedder.spec.ts
+++ b/cypress/integration/linkEmbedder.spec.ts
@@ -6,6 +6,7 @@
 
 describe('Link gets replaced with embedding: ', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.visitTestEditor()
   })
 

--- a/cypress/integration/maxLength.spec.ts
+++ b/cypress/integration/maxLength.spec.ts
@@ -10,6 +10,7 @@ describe('The status bar text length info', () => {
   const tooMuchTestContent = `${ dangerTestContent }a`
 
   beforeEach(() => {
+    cy.loadConfig()
     cy.visitTestEditor()
   })
 

--- a/cypress/integration/profile.spec.ts
+++ b/cypress/integration/profile.spec.ts
@@ -6,6 +6,7 @@
 
 describe('profile page', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.intercept({
       url: '/api/v2/tokens',
       method: 'GET'

--- a/cypress/integration/quote-extra.spec.ts
+++ b/cypress/integration/quote-extra.spec.ts
@@ -6,6 +6,7 @@
 
 describe('Quote extra tags', function () {
   beforeEach(() => {
+    cy.loadConfig()
     cy.visitTestEditor()
   })
 

--- a/cypress/integration/shortcodes.spec.ts
+++ b/cypress/integration/shortcodes.spec.ts
@@ -6,6 +6,7 @@
 
 describe('Short code gets replaced or rendered: ', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.visitTestEditor()
   })
 

--- a/cypress/integration/signInButton.spec.ts
+++ b/cypress/integration/signInButton.spec.ts
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { config } from '../support/config'
+
+const authProvidersDisabled = {
+  facebook: false,
+  github: false,
+  twitter: false,
+  gitlab: false,
+  dropbox: false,
+  ldap: false,
+  google: false,
+  saml: false,
+  oauth2: false,
+  internal: false,
+  openid: false
+}
+
+const interceptConfigWithAuthProviders = (cy: Cypress.cy, enabledProviders: Partial<typeof authProvidersDisabled>) => {
+  cy.intercept('/api/v2/config', {
+    statusCode: 200,
+    body: {
+      ...config,
+      authProviders: {
+        ...authProvidersDisabled,
+        ...enabledProviders
+      }
+    }
+  })
+}
+
+describe('When logged-in, ', () => {
+  it('sign-in button is hidden', () => {
+    cy.visit('/')
+    cy.get('[data-cy=sign-in-button]')
+      .should('not.exist')
+  })
+})
+
+describe('When logged-out ', () => {
+  beforeEach(() => {
+    cy.visit('/')
+    cy.logout()
+  })
+
+  describe('and no auth-provider is enabled, ', () => {
+    it('sign-in button is hidden', () => {
+      interceptConfigWithAuthProviders(cy, {})
+      cy.get('[data-cy=sign-in-button]')
+        .should('not.exist')
+    })
+  })
+
+  describe('and an interactive auth-provider is enabled, ', () => {
+    it('sign-in button points to login route: internal', () => {
+      interceptConfigWithAuthProviders(cy, {
+        internal: true
+      })
+      cy.get('[data-cy=sign-in-button]')
+        .should('be.visible')
+        .should('have.attr', 'href', '/login')
+    })
+
+    it('sign-in button points to login route: ldap', () => {
+      interceptConfigWithAuthProviders(cy, {
+        ldap: true
+      })
+      cy.get('[data-cy=sign-in-button]')
+        .should('be.visible')
+        .should('have.attr', 'href', '/login')
+    })
+
+    it('sign-in button points to login route: openid', () => {
+      interceptConfigWithAuthProviders(cy, {
+        openid: true
+      })
+      cy.get('[data-cy=sign-in-button]')
+        .should('be.visible')
+        .should('have.attr', 'href', '/login')
+    })
+  })
+
+  describe('and only one one-click auth-provider is enabled, ', () => {
+    it('sign-in button points to auth-provider', () => {
+      interceptConfigWithAuthProviders(cy, {
+        saml: true
+      })
+      cy.get('[data-cy=sign-in-button]')
+        .should('be.visible')
+        .should('have.attr', 'href', '/api/v2/auth/saml')
+    })
+  })
+
+  describe('and multiple one-click auth-providers are enabled, ', () => {
+    it('sign-in button points to login route', () => {
+      interceptConfigWithAuthProviders(cy, {
+        saml: true,
+        github: true
+      })
+      cy.get('[data-cy=sign-in-button]')
+        .should('be.visible')
+        .should('have.attr', 'href', '/login')
+    })
+  })
+
+  describe('and one-click- as well as interactive auth-providers are enabled, ', () => {
+    it('sign-in button points to login route', () => {
+      interceptConfigWithAuthProviders(cy, {
+        saml: true,
+        internal: true
+      })
+      cy.get('[data-cy=sign-in-button]')
+        .should('be.visible')
+        .should('have.attr', 'href', '/login')
+    })
+  })
+})

--- a/cypress/integration/signInButton.spec.ts
+++ b/cypress/integration/signInButton.spec.ts
@@ -18,13 +18,15 @@ const authProvidersDisabled = {
   openid: false
 }
 
-const interceptConfigWithAuthProviders = (cy: Cypress.cy, enabledProviders: Partial<typeof authProvidersDisabled>) => {
+const initLoggedOutTestWithCustomAuthProviders = (cy: Cypress.cy, enabledProviders: Partial<typeof authProvidersDisabled>) => {
   cy.loadConfig({
     authProviders: {
       ...authProvidersDisabled,
       ...enabledProviders
     }
   })
+  cy.visit('/')
+  cy.logout()
 }
 
 describe('When logged-in, ', () => {
@@ -37,15 +39,9 @@ describe('When logged-in, ', () => {
 })
 
 describe('When logged-out ', () => {
-  beforeEach(() => {
-    cy.loadConfig()
-    cy.visit('/')
-    cy.logout()
-  })
-
   describe('and no auth-provider is enabled, ', () => {
     it('sign-in button is hidden', () => {
-      interceptConfigWithAuthProviders(cy, {})
+      initLoggedOutTestWithCustomAuthProviders(cy, {})
       cy.get('[data-cy=sign-in-button]')
         .should('not.exist')
     })
@@ -53,7 +49,7 @@ describe('When logged-out ', () => {
 
   describe('and an interactive auth-provider is enabled, ', () => {
     it('sign-in button points to login route: internal', () => {
-      interceptConfigWithAuthProviders(cy, {
+      initLoggedOutTestWithCustomAuthProviders(cy, {
         internal: true
       })
       cy.get('[data-cy=sign-in-button]')
@@ -62,7 +58,7 @@ describe('When logged-out ', () => {
     })
 
     it('sign-in button points to login route: ldap', () => {
-      interceptConfigWithAuthProviders(cy, {
+      initLoggedOutTestWithCustomAuthProviders(cy, {
         ldap: true
       })
       cy.get('[data-cy=sign-in-button]')
@@ -71,7 +67,7 @@ describe('When logged-out ', () => {
     })
 
     it('sign-in button points to login route: openid', () => {
-      interceptConfigWithAuthProviders(cy, {
+      initLoggedOutTestWithCustomAuthProviders(cy, {
         openid: true
       })
       cy.get('[data-cy=sign-in-button]')
@@ -82,18 +78,19 @@ describe('When logged-out ', () => {
 
   describe('and only one one-click auth-provider is enabled, ', () => {
     it('sign-in button points to auth-provider', () => {
-      interceptConfigWithAuthProviders(cy, {
+      initLoggedOutTestWithCustomAuthProviders(cy, {
         saml: true
       })
       cy.get('[data-cy=sign-in-button]')
         .should('be.visible')
-        .should('have.attr', 'href', '/api/v2/auth/saml')
+        // The absolute URL is used because it is defined as API base URL absolute.
+        .should('have.attr', 'href', 'http://127.0.0.1:3001/api/v2/auth/saml')
     })
   })
 
   describe('and multiple one-click auth-providers are enabled, ', () => {
     it('sign-in button points to login route', () => {
-      interceptConfigWithAuthProviders(cy, {
+      initLoggedOutTestWithCustomAuthProviders(cy, {
         saml: true,
         github: true
       })
@@ -105,7 +102,7 @@ describe('When logged-out ', () => {
 
   describe('and one-click- as well as interactive auth-providers are enabled, ', () => {
     it('sign-in button points to login route', () => {
-      interceptConfigWithAuthProviders(cy, {
+      initLoggedOutTestWithCustomAuthProviders(cy, {
         saml: true,
         internal: true
       })

--- a/cypress/integration/signInButton.spec.ts
+++ b/cypress/integration/signInButton.spec.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { config } from '../support/config'
-
 const authProvidersDisabled = {
   facebook: false,
   github: false,
@@ -21,20 +19,17 @@ const authProvidersDisabled = {
 }
 
 const interceptConfigWithAuthProviders = (cy: Cypress.cy, enabledProviders: Partial<typeof authProvidersDisabled>) => {
-  cy.intercept('/api/v2/config', {
-    statusCode: 200,
-    body: {
-      ...config,
-      authProviders: {
-        ...authProvidersDisabled,
-        ...enabledProviders
-      }
+  cy.loadConfig({
+    authProviders: {
+      ...authProvidersDisabled,
+      ...enabledProviders
     }
   })
 }
 
 describe('When logged-in, ', () => {
   it('sign-in button is hidden', () => {
+    cy.loadConfig()
     cy.visit('/')
     cy.get('[data-cy=sign-in-button]')
       .should('not.exist')
@@ -43,6 +38,7 @@ describe('When logged-in, ', () => {
 
 describe('When logged-out ', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.visit('/')
     cy.logout()
   })

--- a/cypress/integration/toolbar.spec.ts
+++ b/cypress/integration/toolbar.spec.ts
@@ -9,6 +9,7 @@ describe('Toolbar Buttons', () => {
   const testLink = 'http://hedgedoc.org'
 
   beforeEach(() => {
+    cy.loadConfig()
     cy.visitTestEditor()
 
     cy.get('.CodeMirror')

--- a/cypress/integration/yamlArrayDeprecationMessage.spec.ts
+++ b/cypress/integration/yamlArrayDeprecationMessage.spec.ts
@@ -6,6 +6,7 @@
 
 describe('YAML Array for deprecated syntax of document tags in frontmatter', () => {
   beforeEach(() => {
+    cy.loadConfig()
     cy.visitTestEditor()
   })
 

--- a/cypress/support/config.ts
+++ b/cypress/support/config.ts
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+declare namespace Cypress {
+  interface Chainable {
+    loadConfig(): Chainable<Window>
+  }
+}
+
 export const banner = {
   text: 'This is the mock banner call',
   timestamp: '2020-05-22T20:46:08.962Z'
@@ -56,9 +62,12 @@ export const config = {
   }
 }
 
-beforeEach(() => {
-  cy.intercept('/api/v2/config', {
+Cypress.Commands.add('loadConfig', (additionalConfig: Partial<typeof config>) => {
+  return cy.intercept('/api/v2/config', {
     statusCode: 200,
-    body: config
+    body: {
+      ...config,
+      ...additionalConfig
+    }
   })
 })

--- a/cypress/support/config.ts
+++ b/cypress/support/config.ts
@@ -14,47 +14,51 @@ export const branding = {
   logo: '/img/acme.png'
 }
 
+export const authProviders = {
+  facebook: true,
+  github: true,
+  twitter: true,
+  gitlab: true,
+  dropbox: true,
+  ldap: true,
+  google: true,
+  saml: true,
+  oauth2: true,
+  internal: true,
+  openid: true
+}
+
+export const config = {
+  allowAnonymous: true,
+  authProviders: authProviders,
+  branding: branding,
+  banner: banner,
+  customAuthNames: {
+    ldap: 'FooBar',
+    oauth2: 'Olaf2',
+    saml: 'aufSAMLn.de'
+  },
+  maxDocumentLength: 200,
+  specialLinks: {
+    privacy: 'https://example.com/privacy',
+    termsOfUse: 'https://example.com/termsOfUse',
+    imprint: 'https://example.com/imprint'
+  },
+  plantumlServer: 'http://mock-plantuml.local',
+  version: {
+    version: 'mock',
+    sourceCodeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    issueTrackerUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+  },
+  'iframeCommunication': {
+    'editorOrigin': 'http://127.0.0.1:3001',
+    'rendererOrigin': 'http://127.0.0.1:3001'
+  }
+}
+
 beforeEach(() => {
   cy.intercept('/api/v2/config', {
     statusCode: 200,
-    body: {
-      allowAnonymous: true,
-      authProviders: {
-        facebook: true,
-        github: true,
-        twitter: true,
-        gitlab: true,
-        dropbox: true,
-        ldap: true,
-        google: true,
-        saml: true,
-        oauth2: true,
-        email: true,
-        openid: true
-      },
-      branding: branding,
-      banner: banner,
-      customAuthNames: {
-        ldap: 'FooBar',
-        oauth2: 'Olaf2',
-        saml: 'aufSAMLn.de'
-      },
-      maxDocumentLength: 200,
-      specialLinks: {
-        privacy: 'https://example.com/privacy',
-        termsOfUse: 'https://example.com/termsOfUse',
-        imprint: 'https://example.com/imprint'
-      },
-      plantumlServer: 'http://mock-plantuml.local',
-      version: {
-        version: 'mock',
-        sourceCodeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-        issueTrackerUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
-      },
-      'iframeCommunication': {
-        'editorOrigin': 'http://127.0.0.1:3001',
-        'rendererOrigin': 'http://127.0.0.1:3001'
-      }
-    }
+    body: config
   })
 })

--- a/cypress/support/config.ts
+++ b/cypress/support/config.ts
@@ -62,7 +62,7 @@ export const config = {
   }
 }
 
-Cypress.Commands.add('loadConfig', (additionalConfig: Partial<typeof config>) => {
+Cypress.Commands.add('loadConfig', (additionalConfig?: Partial<typeof config>) => {
   return cy.intercept('/api/v2/config', {
     statusCode: 200,
     body: {

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -7,6 +7,8 @@
 import { RegisterError } from '../../components/register-page/register-page'
 import { defaultFetchConfig, expectResponseCode, getApiUrl } from '../utils'
 
+export const INTERACTIVE_LOGIN_METHODS = ['internal', 'ldap', 'openid']
+
 export const doInternalLogin = async (username: string, password: string): Promise<void> => {
   const response = await fetch(getApiUrl() + '/auth/internal', {
     ...defaultFetchConfig,

--- a/src/components/landing-layout/navigation/sign-in-button.tsx
+++ b/src/components/landing-layout/navigation/sign-in-button.tsx
@@ -14,10 +14,9 @@ import { LinkContainer } from 'react-router-bootstrap'
 import { ApplicationState } from '../../../redux'
 import { ShowIf } from '../../common/show-if/show-if'
 import { getApiUrl } from '../../../api/utils'
+import { INTERACTIVE_LOGIN_METHODS } from '../../../api/auth'
 
 export type SignInButtonProps = Omit<ButtonProps, 'href'>
-
-const INTERACTIVE_LOGIN_METHODS = ['internal', 'ldap', 'openid']
 
 export const SignInButton: React.FC<SignInButtonProps> = ({ variant, ...props }) => {
   const { t } = useTranslation()

--- a/src/components/landing-layout/navigation/sign-in-button.tsx
+++ b/src/components/landing-layout/navigation/sign-in-button.tsx
@@ -5,7 +5,7 @@
  */
 
 import equal from 'fast-deep-equal'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useMemo, useRef } from 'react'
 import { Button } from 'react-bootstrap'
 import { ButtonProps } from 'react-bootstrap/Button'
 import { Trans, useTranslation } from 'react-i18next'
@@ -21,19 +21,19 @@ export type SignInButtonProps = Omit<ButtonProps, 'href'>
 export const SignInButton: React.FC<SignInButtonProps> = ({ variant, ...props }) => {
   const { t } = useTranslation()
   const authProviders = useSelector((state: ApplicationState) => state.config.authProviders, equal)
-  const [loginLink, setLoginLink] = useState('/login')
   const authEnabled = useRef(Object.values(authProviders).includes(true))
 
-  useEffect(() => {
+  const loginLink = useMemo(() => {
     const activeProviders = Object.entries(authProviders)
                                   .filter((entry: [string, boolean]) => entry[1])
                                   .map(entry => entry[0])
     const activeOneClickProviders = activeProviders.filter(entry => !INTERACTIVE_LOGIN_METHODS.includes(entry))
 
     if (activeProviders.length === 1 && activeOneClickProviders.length === 1) {
-      setLoginLink(`${ getApiUrl() }/auth/${ activeOneClickProviders[0] }`)
+      return `${ getApiUrl() }/auth/${ activeOneClickProviders[0] }`
     }
-  }, [authProviders, setLoginLink])
+    return '/login'
+  }, [authProviders])
 
   return (
     <ShowIf condition={ authEnabled.current }>

--- a/src/components/landing-layout/navigation/sign-in-button.tsx
+++ b/src/components/landing-layout/navigation/sign-in-button.tsx
@@ -13,6 +13,7 @@ import { useSelector } from 'react-redux'
 import { LinkContainer } from 'react-router-bootstrap'
 import { ApplicationState } from '../../../redux'
 import { ShowIf } from '../../common/show-if/show-if'
+import { getApiUrl } from '../../../api/utils'
 
 export type SignInButtonProps = Omit<ButtonProps, 'href'>
 
@@ -30,7 +31,7 @@ export const SignInButton: React.FC<SignInButtonProps> = ({ variant, ...props })
     const activeOneClickProviders = activeProviders.filter(entry => !INTERACTIVE_LOGIN_METHODS.includes(entry))
 
     if (activeProviders.length === 1 && activeOneClickProviders.length === 1) {
-      setLoginLink(`/api/v2/auth/${activeOneClickProviders[0]}`)
+      setLoginLink(`${ getApiUrl() }/auth/${ activeOneClickProviders[0] }`)
     }
   }, [authProviders, setLoginLink])
 

--- a/src/components/landing-layout/navigation/sign-in-button.tsx
+++ b/src/components/landing-layout/navigation/sign-in-button.tsx
@@ -5,7 +5,7 @@
  */
 
 import equal from 'fast-deep-equal'
-import React, { useMemo, useRef } from 'react'
+import React, { useMemo } from 'react'
 import { Button } from 'react-bootstrap'
 import { ButtonProps } from 'react-bootstrap/Button'
 import { Trans, useTranslation } from 'react-i18next'
@@ -21,7 +21,7 @@ export type SignInButtonProps = Omit<ButtonProps, 'href'>
 export const SignInButton: React.FC<SignInButtonProps> = ({ variant, ...props }) => {
   const { t } = useTranslation()
   const authProviders = useSelector((state: ApplicationState) => state.config.authProviders, equal)
-  const authEnabled = useRef(Object.values(authProviders).includes(true))
+  const authEnabled = useMemo(() => Object.values(authProviders).includes(true), [authProviders])
 
   const loginLink = useMemo(() => {
     const activeProviders = Object.entries(authProviders)
@@ -36,7 +36,7 @@ export const SignInButton: React.FC<SignInButtonProps> = ({ variant, ...props })
   }, [authProviders])
 
   return (
-    <ShowIf condition={ authEnabled.current }>
+    <ShowIf condition={ authEnabled }>
       <LinkContainer to={ loginLink } title={ t('login.signIn') }>
         <Button
           data-cy={ 'sign-in-button' }

--- a/src/components/landing-layout/navigation/sign-in-button.tsx
+++ b/src/components/landing-layout/navigation/sign-in-button.tsx
@@ -5,7 +5,7 @@
  */
 
 import equal from 'fast-deep-equal'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Button } from 'react-bootstrap'
 import { ButtonProps } from 'react-bootstrap/Button'
 import { Trans, useTranslation } from 'react-i18next'
@@ -23,10 +23,11 @@ export const SignInButton: React.FC<SignInButtonProps> = ({ variant, ...props })
   const { t } = useTranslation()
   const authProviders = useSelector((state: ApplicationState) => state.config.authProviders, equal)
   const [loginLink, setLoginLink] = useState('/login')
+  const authEnabled = useRef(Object.values(authProviders).includes(true))
 
   useEffect(() => {
     const activeProviders = Object.entries(authProviders)
-                                  .filter(entry => entry[1] === true)
+                                  .filter((entry: [string, boolean]) => entry[1])
                                   .map(entry => entry[0])
     const activeOneClickProviders = activeProviders.filter(entry => !INTERACTIVE_LOGIN_METHODS.includes(entry))
 
@@ -36,7 +37,7 @@ export const SignInButton: React.FC<SignInButtonProps> = ({ variant, ...props })
   }, [authProviders, setLoginLink])
 
   return (
-    <ShowIf condition={ Object.values(authProviders).includes(true) }>
+    <ShowIf condition={ authEnabled.current }>
       <LinkContainer to={ loginLink } title={ t('login.signIn') }>
         <Button
           data-cy={ 'sign-in-button' }


### PR DESCRIPTION
### Component/Part
Sign-in button in the app-bar

### Description
This PR improves the sign-in button as this links now directly to the auth-provider if only one provider is enabled which doesn't require additional user input in our frontend.

Note that the e2e tests currently fail due to a cypress limitation for which we need to find a workaround.

@mrdrogdrog: Sentences in the tests. Only for you.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] Extended changelog
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
Closes #1042 
