### PR TITLE
Set sanitized note title as filename for download

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
         "react-scripts": "4.0.2",
         "react-use": "17.1.1",
         "redux": "4.0.5",
+        "sanitize-filename": "^1.6.3",
         "ts-mockery": "1.2.0",
         "typescript": "4.1.5",
         "use-resize-observer": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
         "react-scripts": "4.0.2",
         "react-use": "17.1.1",
         "redux": "4.0.5",
-        "sanitize-filename": "^1.6.3",
+        "sanitize-filename": "1.6.3",
         "ts-mockery": "1.2.0",
         "typescript": "4.1.5",
         "use-resize-observer": "7.0.0",

--- a/src/components/editor-page/sidebar/export-markdown-sidebar-entry.tsx
+++ b/src/components/editor-page/sidebar/export-markdown-sidebar-entry.tsx
@@ -14,12 +14,11 @@ import { SidebarButton } from './sidebar-button'
 
 export const ExportMarkdownSidebarEntry: React.FC = () => {
   const { t } = useTranslation()
-  const noteTitle = store.getState().noteDetails.noteTitle
   const markdownContent = useNoteMarkdownContent()
   const onClick = useCallback(() => {
-    const sanitized = sanitize(noteTitle)
+    const sanitized = sanitize(store.getState().noteDetails.noteTitle)
     download(markdownContent, `${ sanitized !== '' ? sanitized : t('editor.untitledNote') }.md`, 'text/markdown')
-  }, [markdownContent, noteTitle, t])
+  }, [markdownContent, t])
 
   return (
     <SidebarButton data-cy={ 'menu-export-markdown' } onClick={ onClick } icon={ 'file-text' }>

--- a/src/components/editor-page/sidebar/export-markdown-sidebar-entry.tsx
+++ b/src/components/editor-page/sidebar/export-markdown-sidebar-entry.tsx
@@ -5,18 +5,22 @@
  */
 
 import React, { useCallback } from 'react'
+import sanitize from 'sanitize-filename'
 import { Trans, useTranslation } from 'react-i18next'
 import { useNoteMarkdownContent } from '../../../hooks/common/use-note-markdown-content'
 import { download } from '../../common/download/download'
 import { SidebarButton } from './sidebar-button'
+import { useSelector } from 'react-redux'
+import { ApplicationState } from '../../../redux'
 
 export const ExportMarkdownSidebarEntry: React.FC = () => {
-  useTranslation()
-
+  const { t } = useTranslation()
+  const noteTitle = useSelector((state: ApplicationState) => state.noteDetails.noteTitle)
   const markdownContent = useNoteMarkdownContent()
   const onClick = useCallback(() => {
-    download(markdownContent, `title.md`, 'text/markdown') //todo: replace hard coded title with redux
-  }, [markdownContent])
+    const sanitized = sanitize(noteTitle)
+    download(markdownContent, `${ sanitized !== '' ? sanitized : t('editor.untitledNote') }.md`, 'text/markdown')
+  }, [markdownContent, noteTitle, t])
 
   return (
     <SidebarButton data-cy={ 'menu-export-markdown' } onClick={ onClick } icon={ 'file-text' }>

--- a/src/components/editor-page/sidebar/export-markdown-sidebar-entry.tsx
+++ b/src/components/editor-page/sidebar/export-markdown-sidebar-entry.tsx
@@ -6,16 +6,15 @@
 
 import React, { useCallback } from 'react'
 import sanitize from 'sanitize-filename'
+import { store } from '../../../redux'
 import { Trans, useTranslation } from 'react-i18next'
 import { useNoteMarkdownContent } from '../../../hooks/common/use-note-markdown-content'
 import { download } from '../../common/download/download'
 import { SidebarButton } from './sidebar-button'
-import { useSelector } from 'react-redux'
-import { ApplicationState } from '../../../redux'
 
 export const ExportMarkdownSidebarEntry: React.FC = () => {
   const { t } = useTranslation()
-  const noteTitle = useSelector((state: ApplicationState) => state.noteDetails.noteTitle)
+  const noteTitle = store.getState().noteDetails.noteTitle
   const markdownContent = useNoteMarkdownContent()
   const onClick = useCallback(() => {
     const sanitized = sanitize(noteTitle)

--- a/yarn.lock
+++ b/yarn.lock
@@ -12770,7 +12770,7 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sanitize-filename@^1.6.3:
+sanitize-filename@1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.3.tgz#755ebd752045931977e30b2025d340d7c9090378"
   integrity sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -12770,6 +12770,13 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
+sanitize-filename@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.3.tgz#755ebd752045931977e30b2025d340d7c9090378"
+  integrity sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==
+  dependencies:
+    truncate-utf8-bytes "^1.0.0"
+
 sanitize.css@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/sanitize.css/-/sanitize.css-10.0.0.tgz#b5cb2547e96d8629a60947544665243b1dc3657a"
@@ -14023,6 +14030,13 @@ trim-newlines@^1.0.0:
   dependencies:
     glob "^7.1.2"
 
+truncate-utf8-bytes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
+  integrity sha1-QFkjkJWS1W94pYGENLC3hInKXys=
+  dependencies:
+    utf8-byte-length "^1.0.1"
+
 try-catch@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/try-catch/-/try-catch-2.0.1.tgz#a35d354187c422f291a0bcfd9eb77e3a4f90c1e5"
@@ -14379,6 +14393,11 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+utf8-byte-length@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
+  integrity sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
### Component/Part
Editor -> export -> markdown file

### Description
This PR sets the note title as filename for markdown download. It will be sanitized to ensure to not break any filesystems.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
none
