### PR TITLE
Add context for iframe communicator in editor page

### DIFF
--- a/src/components/editor-page/render-context/iframe-communicator-context-provider.tsx
+++ b/src/components/editor-page/render-context/iframe-communicator-context-provider.tsx
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import React, { useContext, useMemo } from 'react'
+import { IframeEditorToRendererCommunicator } from '../../render-page/iframe-editor-to-renderer-communicator'
+
+const IFrameEditorToRendererCommunicatorContext = React.createContext<IframeEditorToRendererCommunicator | undefined>(undefined)
+
+export const useIFrameCommunicator: () => IframeEditorToRendererCommunicator | undefined = () => useContext(IFrameEditorToRendererCommunicatorContext)
+
+export const useContextOrStandaloneIframeCommunicator: () => IframeEditorToRendererCommunicator = () => {
+  const contextCommunicator = useIFrameCommunicator()
+  return useMemo(() => contextCommunicator ? contextCommunicator : new IframeEditorToRendererCommunicator(), [contextCommunicator])
+}
+
+export const IframeCommunicatorContextProvider: React.FC = ({ children }) => {
+  const currentIFrameCommunicator = useMemo<IframeEditorToRendererCommunicator>(() => new IframeEditorToRendererCommunicator(), [])
+
+  return <IFrameEditorToRendererCommunicatorContext.Provider value={ currentIFrameCommunicator }>
+    { children }
+  </IFrameEditorToRendererCommunicatorContext.Provider>
+}

--- a/src/components/editor-page/renderer-pane/render-iframe.tsx
+++ b/src/components/editor-page/renderer-pane/render-iframe.tsx
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import equal from 'fast-deep-equal'
-import React, { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useIsDarkModeActivated } from '../../../hooks/common/use-is-dark-mode-activated'
 import { ApplicationState } from '../../../redux'
 import { isTestMode } from '../../../utils/is-test-mode'
-import { IframeEditorToRendererCommunicator } from '../../render-page/iframe-editor-to-renderer-communicator'
 import { RendererProps } from '../../render-page/markdown-document'
 import { ImageDetails, RendererType } from '../../render-page/rendering-message'
+import { useContextOrStandaloneIframeCommunicator } from '../render-context/iframe-communicator-context-provider'
 import { ScrollState } from '../synced-scroll/scroll-props'
 import { useOnIframeLoad } from './hooks/use-on-iframe-load'
 import { ShowOnPropChangeImageLightbox } from './show-on-prop-change-image-lightbox'
@@ -46,7 +46,7 @@ export const RenderIframe: React.FC<RenderIframeProps> = (
   const rendererOrigin = useSelector((state: ApplicationState) => state.config.iframeCommunication.rendererOrigin)
   const renderPageUrl = `${ rendererOrigin }/render`
   const resetRendererReady = useCallback(() => setRendererReady(false), [])
-  const iframeCommunicator = useMemo(() => new IframeEditorToRendererCommunicator(), [])
+  const iframeCommunicator = useContextOrStandaloneIframeCommunicator()
   const onIframeLoad = useOnIframeLoad(frameReference, iframeCommunicator, rendererOrigin, renderPageUrl, resetRendererReady)
   const [frameHeight, setFrameHeight] = useState<number>(0)
 


### PR DESCRIPTION
### Component/Part
Edit page

### Description
This PR creates a react context for the iframe communicator. This is useful if some functions (like sidebar actions) should be able to communicate with the renderer.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
