### PR TITLE
The History PR: III - Editor integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 - The intro page content can be changed by editing `public/intro.md`.
 - When pasting tables (e.g. from LibreOffice Calc or MS Excel) they get reformatted to markdown tables.
 - The history page supports URL parameters that allow bookmarking of a specific search of tags filter.
+- Users can change the pinning state of a note directly from the editor.
 
 ### Changed
 

--- a/src/components/editor-page/editor-page.tsx
+++ b/src/components/editor-page/editor-page.tsx
@@ -35,7 +35,7 @@ import { useEditorModeFromUrl } from './hooks/useEditorModeFromUrl'
 import { UiNotifications } from '../notifications/ui-notifications'
 import { useNotificationTest } from './use-notification-test'
 import { IframeCommunicatorContextProvider } from './render-context/iframe-communicator-context-provider'
-import { useUpdateHistoryEntry } from './hooks/useUpdateHistoryEntry'
+import { useUpdateLocalHistoryEntry } from './hooks/useUpdateLocalHistoryEntry'
 
 export interface EditorPagePathParams {
   id: string
@@ -78,7 +78,7 @@ export const EditorPage: React.FC = () => {
 
   const [error, loading] = useLoadNoteFromServer()
 
-  useUpdateHistoryEntry(loading, error)
+  useUpdateLocalHistoryEntry(!error && !loading)
 
   const setRendererToScrollSource = useCallback(() => {
     scrollSource.current = ScrollSource.RENDERER

--- a/src/components/editor-page/editor-page.tsx
+++ b/src/components/editor-page/editor-page.tsx
@@ -35,6 +35,7 @@ import { useEditorModeFromUrl } from './hooks/useEditorModeFromUrl'
 import { UiNotifications } from '../notifications/ui-notifications'
 import { useNotificationTest } from './use-notification-test'
 import { IframeCommunicatorContextProvider } from './render-context/iframe-communicator-context-provider'
+import { useUpdateHistoryEntry } from './hooks/useUpdateHistoryEntry'
 
 export interface EditorPagePathParams {
   id: string
@@ -76,6 +77,8 @@ export const EditorPage: React.FC = () => {
   useEditorModeFromUrl()
 
   const [error, loading] = useLoadNoteFromServer()
+
+  useUpdateHistoryEntry(loading, error)
 
   const setRendererToScrollSource = useCallback(() => {
     scrollSource.current = ScrollSource.RENDERER

--- a/src/components/editor-page/hooks/useUpdateHistoryEntry.ts
+++ b/src/components/editor-page/hooks/useUpdateHistoryEntry.ts
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import equal from 'fast-deep-equal'
+import { useCallback, useEffect, useRef } from 'react'
+import { useSelector } from 'react-redux'
+import { ApplicationState, store } from '../../../redux'
+import { useParams } from 'react-router-dom'
+import { EditorPagePathParams } from '../editor-page'
+import { HistoryEntry, HistoryEntryOrigin } from '../../../redux/history/types'
+import { updateHistoryEntry } from '../../../redux/history/methods'
+
+export const useUpdateHistoryEntry = (loading: boolean, error: boolean): void => {
+  const { id } = useParams<EditorPagePathParams>()
+  const userExists = useSelector((state: ApplicationState) => !!state.user)
+  const noteTitle = useSelector((state: ApplicationState) => state.noteDetails.noteTitle)
+  const noteTags = useSelector((state: ApplicationState) => state.noteDetails.frontmatter.tags)
+
+  const lastTitle = useRef('')
+  const lastTags = useRef<string[]>([])
+
+
+  const updateHistory = useCallback(() => {
+    if (loading || error) {
+      return
+    }
+    // This is needed to not update the history entry on each scroll without changes
+    // just because title or tags redux state were touched.
+    if (noteTitle === lastTitle.current && equal(noteTags, lastTags.current)) {
+      return
+    }
+    const history = store.getState().history
+    const entry: HistoryEntry = history.find(entry => entry.id === id) ?? {
+      id,
+      title: '',
+      pinned: false,
+      lastVisited: '',
+      tags: [],
+      origin: userExists ? HistoryEntryOrigin.REMOTE : HistoryEntryOrigin.LOCAL
+    }
+    entry.title = noteTitle
+    entry.tags = noteTags
+    entry.lastVisited = new Date().toISOString()
+    updateHistoryEntry(id, entry)
+    lastTitle.current = noteTitle
+    lastTags.current = noteTags
+  }, [error, loading, id, noteTitle, noteTags, userExists])
+
+  useEffect(updateHistory, [loading, updateHistory, noteTitle, noteTags])
+}

--- a/src/components/editor-page/sidebar/pin-note-sidebar-entry.tsx
+++ b/src/components/editor-page/sidebar/pin-note-sidebar-entry.tsx
@@ -20,11 +20,11 @@ export const PinNoteSidebarEntry: React.FC<SpecificSidebarEntryProps> = ({ class
   const history = useSelector((state: ApplicationState) => state.history)
 
   const isPinned = useMemo(() => {
-    const entry = history.find(entry => entry.id === id)
+    const entry = history.find(entry => entry.identifier === id)
     if (!entry) {
       return false
     }
-    return entry.pinned
+    return entry.pinStatus
   }, [id, history])
 
   const onPinClicked = useCallback(() => {

--- a/src/components/editor-page/sidebar/pin-note-sidebar-entry.tsx
+++ b/src/components/editor-page/sidebar/pin-note-sidebar-entry.tsx
@@ -13,9 +13,10 @@ import { EditorPagePathParams } from '../editor-page'
 import { useSelector } from 'react-redux'
 import { ApplicationState } from '../../../redux'
 import { toggleHistoryEntryPinning } from '../../../redux/history/methods'
+import { showErrorNotification } from '../../../redux/ui-notifications/methods'
 
 export const PinNoteSidebarEntry: React.FC<SpecificSidebarEntryProps> = ({ className, hide }) => {
-  useTranslation()
+  const { t } = useTranslation()
   const { id } = useParams<EditorPagePathParams>()
   const history = useSelector((state: ApplicationState) => state.history)
 
@@ -28,8 +29,10 @@ export const PinNoteSidebarEntry: React.FC<SpecificSidebarEntryProps> = ({ class
   }, [id, history])
 
   const onPinClicked = useCallback(() => {
-    toggleHistoryEntryPinning(id)
-  }, [id])
+    toggleHistoryEntryPinning(id).catch(
+      showErrorNotification(t('landing.history.error.updateEntry.text'))
+    )
+  }, [id, t])
 
   return (
     <SidebarButton icon={ 'thumb-tack' } hide={ hide } onClick={ onPinClicked }

--- a/src/components/editor-page/sidebar/pin-note-sidebar-entry.tsx
+++ b/src/components/editor-page/sidebar/pin-note-sidebar-entry.tsx
@@ -4,20 +4,37 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { SidebarButton } from './sidebar-button'
 import { SpecificSidebarEntryProps } from './types'
+import { useParams } from 'react-router-dom'
+import { EditorPagePathParams } from '../editor-page'
+import { useSelector } from 'react-redux'
+import { ApplicationState } from '../../../redux'
+import { toggleHistoryEntryPinning } from '../../../redux/history/methods'
 
 export const PinNoteSidebarEntry: React.FC<SpecificSidebarEntryProps> = ({ className, hide }) => {
   useTranslation()
+  const { id } = useParams<EditorPagePathParams>()
+  const history = useSelector((state: ApplicationState) => state.history)
 
-  const isPinned = true
-  const i18nKey = isPinned ? 'editor.documentBar.pinNoteToHistory' : 'editor.documentBar.pinnedToHistory'
+  const isPinned = useMemo(() => {
+    const entry = history.find(entry => entry.id === id)
+    if (!entry) {
+      return false
+    }
+    return entry.pinned
+  }, [id, history])
+
+  const onPinClicked = useCallback(() => {
+    toggleHistoryEntryPinning(id)
+  }, [id])
 
   return (
-    <SidebarButton icon={ 'thumb-tack' } className={ className } hide={ hide }>
-      <Trans i18nKey={ i18nKey }/>
+    <SidebarButton icon={ 'thumb-tack' } hide={ hide } onClick={ onPinClicked }
+                   className={ `${ className ?? '' } ${ isPinned ? 'icon-highlighted' : '' }` }>
+      <Trans i18nKey={ isPinned ? 'editor.documentBar.pinnedToHistory' : 'editor.documentBar.pinNoteToHistory' }/>
     </SidebarButton>
   )
 }

--- a/src/components/editor-page/sidebar/style/colors.scss
+++ b/src/components/editor-page/sidebar/style/colors.scss
@@ -33,6 +33,10 @@
         background: $entry-hover-bg;
       }
     }
+
+    &.icon-highlighted > .sidebar-icon {
+      color: $orange
+    }
   }
 }
 


### PR DESCRIPTION
### Component/Part
Editor + sidebar (pin to history)

### Description
This PR adds the integration of the history features into the editor page. This means the following:
 - When a valid note is opened, a history entry is created or the last visited date is updated.
 - When the title or tags of a note change, the history entry will be updated.
 - The pinning state of the note is reflected in the sidebar. A click will toggle that state.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Extended changelog
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
This PR is part of "The History PR" series.

Part I: Move to redux (#1156)
Part II: Add URL params (#1157)
Part III: Editor integration (this)
Part IV: Generalize components for explore page (coming soon)

Closes #331 