### PR TITLE
Add renovate group for vega lite

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,9 @@
   ],
   "packageRules": [
     {
-      "updateTypes": ["pin"],
+      "updateTypes": [
+        "pin"
+      ],
       "automerge": true
     },
     {
@@ -43,6 +45,14 @@
         "markmap-view",
         "markmap-lib",
         "markmap-common"
+      ]
+    },
+    {
+      "groupName": "vega",
+      "packagePatterns": [
+        "vega",
+        "vega-embed",
+        "vega-lite"
       ]
     },
     {


### PR DESCRIPTION
### Component/Part
Vega lite

### Description
This PR adds a renovate group for all vega lite packages

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
