### PR TITLE
Change plantuml server url to https

### DIFF
--- a/public/api/v2/config
+++ b/public/api/v2/config
@@ -29,7 +29,7 @@
   },
   "maxDocumentLength": 100000,
   "useImageProxy": false,
-  "plantumlServer": "http://www.plantuml.com/plantuml",
+  "plantumlServer": "https://www.plantuml.com/plantuml",
   "specialLinks": {
     "privacy": "https://example.com/privacy",
     "termsOfUse": "https://example.com/termsOfUse",


### PR DESCRIPTION
### Component/Part
Frontend mock config

### Description
This PR changes the plantuml server url in the mock config file to "https".

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
