### PR TITLE
Disallow data and javascript URIs

### DIFF
--- a/cypress/integration/linkSchemes.ts
+++ b/cypress/integration/linkSchemes.ts
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+describe('markdown formatted links to', () => {
+  beforeEach(() => {
+    cy.loadConfig()
+    cy.visitTestEditor()
+  })
+
+  it('external domains render as external link', () => {
+    cy.codemirrorFill('[external](https://hedgedoc.org/)')
+    cy.getMarkdownBody()
+      .find('a')
+      .should('have.attr', 'href', 'https://hedgedoc.org/')
+      .should('have.attr', 'rel', 'noreferer noopener')
+      .should('have.attr', 'target', '_blank')
+  })
+
+  it('note anchor references render as anchor link', () => {
+    cy.codemirrorFill('[anchor](#anchor)')
+    cy.getMarkdownBody()
+      .find('a')
+      .should('have.attr', 'href', 'http://127.0.0.1:3001/n/test#anchor')
+  })
+
+  it('internal pages render as internal link', () => {
+    cy.codemirrorFill('[internal](other-note)')
+    cy.getMarkdownBody()
+      .find('a')
+      .should('have.attr', 'href', 'http://127.0.0.1:3001/n/other-note')
+  })
+
+  it('data URIs do not render', () => {
+    cy.codemirrorFill('[data](data:text/plain,evil)')
+    cy.getMarkdownBody()
+      .find('a')
+      .should('not.exist')
+  })
+
+  it('javascript URIs do not render', () => {
+    cy.codemirrorFill('[js](javascript:alert("evil"))')
+    cy.getMarkdownBody()
+      .find('a')
+      .should('not.exist')
+  })
+})
+
+describe('HTML anchor element links to', () => {
+  beforeEach(() => {
+    cy.loadConfig()
+    cy.visitTestEditor()
+  })
+
+  it('external domains render as external link', () => {
+    cy.codemirrorFill('<a href="https://hedgedoc.org/">external</a>')
+    cy.getMarkdownBody()
+      .find('a')
+      .should('have.attr', 'href', 'https://hedgedoc.org/')
+      .should('have.attr', 'rel', 'noreferer noopener')
+      .should('have.attr', 'target', '_blank')
+  })
+
+  it('note anchor references render as anchor link', () => {
+    cy.codemirrorFill('<a href="#anchor">anchor</a>')
+    cy.getMarkdownBody()
+      .find('a')
+      .should('have.attr', 'href', 'http://127.0.0.1:3001/n/test#anchor')
+  })
+
+  it('internal pages render as internal link', () => {
+    cy.codemirrorFill('<a href="other-note">internal</a>')
+    cy.getMarkdownBody()
+      .find('a')
+      .should('have.attr', 'href', 'http://127.0.0.1:3001/n/other-note')
+  })
+
+  it('data URIs do not render', () => {
+    cy.codemirrorFill('<a href="data:text/plain,evil">data</a>')
+    cy.getMarkdownBody()
+      .find('a')
+      .should('not.exist')
+  })
+
+  it('javascript URIs do not render', () => {
+    cy.codemirrorFill('<a href="javascript:alert(\'evil\')">js</a>')
+    cy.getMarkdownBody()
+      .find('a')
+      .should('not.exist')
+  })
+})

--- a/src/components/markdown-renderer/replace-components/link-replacer/link-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/link-replacer/link-replacer.tsx
@@ -26,6 +26,12 @@ export class LinkReplacer extends ComponentReplacer {
     }
 
     const url = node.attribs.href
+
+    // eslint-disable-next-line no-script-url
+    if (url.startsWith('data:') || url.startsWith('javascript:')) {
+      return <span>{ node.attribs.href }</span>
+    }
+
     const isJumpMark = url.substr(0, 1) === '#'
 
     const id = url.substr(1)

--- a/src/components/markdown-renderer/replace-components/link-replacer/link-replacer.tsx
+++ b/src/components/markdown-renderer/replace-components/link-replacer/link-replacer.tsx
@@ -25,7 +25,7 @@ export class LinkReplacer extends ComponentReplacer {
       return undefined
     }
 
-    const url = node.attribs.href
+    const url = node.attribs.href.trim()
 
     // eslint-disable-next-line no-script-url
     if (url.startsWith('data:') || url.startsWith('javascript:')) {


### PR DESCRIPTION
### Component/Part
Markdown renderer

### Description
This PR blocks URIs that begin with `data:` or `javscript:` to avoid something like XSS attacks.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
Fixes #1185 
