### PR TITLE
Fix code highlight indentation

### DIFF
--- a/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.scss
+++ b/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.scss
@@ -25,7 +25,7 @@
 
       .codeline {
         grid-column: 2;
-        white-space: nowrap;
+        white-space: pre;
       }
 
       .linenumber {


### PR DESCRIPTION
### Component/Part
Code Highlighting

### Description
This PR fixes the wrong indentation in non-wrapped code highlighted blocks in the markdown render output. 

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
