### PR TITLE
Use module build of markmap-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "webpack-bundle-analyzer": "4.4.1"
   },
   "resolutions": {
-    "cypress": "7.1.0"
+    "cypress": "7.1.0",
+    "katex": "0.13.2"
   }
 }

--- a/src/components/markdown-renderer/replace-components/markmap/markmap-loader.ts
+++ b/src/components/markdown-renderer/replace-components/markmap/markmap-loader.ts
@@ -1,26 +1,15 @@
 /*
- SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
-
- SPDX-License-Identifier: AGPL-3.0-only
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { loadCSS, loadJS } from 'markmap-common'
-import { Transformer } from 'markmap-lib'
+import { Transformer } from 'markmap-lib/dist/index.esm'
 import { Markmap } from 'markmap-view'
 
 const transformer: Transformer = new Transformer()
 
 export const markmapLoader = (svg: SVGSVGElement, code: string): void => {
-  const { root, features } = transformer.transform(code)
-  const { styles, scripts } = transformer.getUsedAssets(features)
-
-  if (styles) {
-    loadCSS(styles)
-  }
-  if (scripts) {
-    loadJS(scripts)
-      .catch(console.log)
-  }
-
+  const { root } = transformer.transform(code)
   Markmap.create(svg, {}, root)
 }

--- a/src/external-types/markmap-lib/index.d.ts
+++ b/src/external-types/markmap-lib/index.d.ts
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+declare module 'markmap-lib/dist/index.esm' {
+  export * from 'markmap-lib'
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9053,19 +9053,12 @@ jsprim@^1.2.2:
     array-includes "^3.1.2"
     object.assign "^4.1.2"
 
-katex@0.13.2:
+katex@0.13.2, katex@^0.12.0:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/katex/-/katex-0.13.2.tgz#4075b9144e6af992ec9a4b772fa3754763be5f26"
   integrity sha512-u/KhjFDhyPr+70aiBn9SL/9w/QlLagIXBi2NZSbNnBUp2tR8dCjQplyEMkEzniem5gOeSCBjlBUg4VaiWs1JJg==
   dependencies:
     commander "^6.0.0"
-
-katex@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/katex/-/katex-0.12.0.tgz#2fb1c665dbd2b043edcf8a1f5c555f46beaa0cb9"
-  integrity sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==
-  dependencies:
-    commander "^2.19.0"
 
 khroma@^1.1.0:
   version "1.3.0"


### PR DESCRIPTION
### Component/Part
Markmap

### Description
This PR changes the markmap import to a explicit file. 
If we use the default import then webpack will use the "browser" bundle which relies on CDN lazy loading of dependencies.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
