### PR TITLE
TablePicker: Change table cells in picker

### DIFF
--- a/src/components/editor-page/editor-pane/tool-bar/table-picker/table-picker.scss
+++ b/src/components/editor-page/editor-pane/tool-bar/table-picker/table-picker.scss
@@ -11,33 +11,15 @@
   @import "../../../../../style/variables.light";
 
   .table-cell {
-    border-top: 1px solid $dark;
-    border-left: 1px solid $dark;
+    border: 1px solid $gray-700;
+    margin: 1px;
+    border-radius: 2px;
   }
 
   .table-container {
-    border-bottom: 1px solid $dark;
-    border-right: 1px solid $dark;
     display: grid;
     grid-template-columns: repeat(10, 15px [col-start]);
     grid-template-rows: repeat(8, 15px [row-start]);
-  }
-
-  body.dark {
-    @import "../../../../../style/variables.dark";
-
-    .table-cell {
-      border-top: 1px solid $dark;
-      border-left: 1px solid $dark;
-    }
-
-    .table-container {
-      border-bottom: 1px solid $dark;
-      border-right: 1px solid $dark;
-      display: grid;
-      grid-template-columns: repeat(10, 15px [col-start]);
-      grid-template-rows: repeat(8, 15px [row-start]);
-    }
   }
 }
 

--- a/src/components/editor-page/editor-pane/tool-bar/table-picker/table-picker.tsx
+++ b/src/components/editor-page/editor-pane/tool-bar/table-picker/table-picker.tsx
@@ -60,7 +60,7 @@ export const TablePicker: React.FC<TablePickerProps> = ({ show, onDismiss, onTab
               .map((col: number) => (
                   <div
                     key={ `${ row }_${ col }` }
-                    className={ `table-cell ${ tableSize && row < tableSize.rows && col < tableSize.columns ? 'bg-primary' : '' }` }
+                    className={ `table-cell ${ tableSize && row < tableSize.rows && col < tableSize.columns ? 'bg-primary border-primary' : '' }` }
                     onMouseEnter={ () => {
                       setTableSize({
                         rows: row + 1,


### PR DESCRIPTION
### Component/Part
<!-- e.g markdown editor -->

### Description
This PR changes some aspects of the table picker:

- Fix error that the border of table cells was invisible in dark mode
- Add margin to table cells
- Add full border to table cells
- Change border-color while hovering over table cells

#### Light Mode

![image](https://user-images.githubusercontent.com/3978662/115588213-cced5280-a2ce-11eb-8f20-fd16ca66adae.png)

#### Dark Mode

![image](https://user-images.githubusercontent.com/3978662/115588115-b21ade00-a2ce-11eb-803e-051aef5288e0.png)


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.