### PR TITLE
Don't show error if no intro.md was found

### DIFF
--- a/cypress/integration/intro.spec.ts
+++ b/cypress/integration/intro.spec.ts
@@ -11,10 +11,19 @@ describe('Intro page', () => {
     cy.visit('/')
   })
 
-  describe('content', () => {
+  describe('customizable content', () => {
     it('fetches and shows the correct intro page content', () => {
       cy.getMarkdownBody()
         .contains('test content')
+    })
+
+    it('won\'t show anything if no content was found', () => {
+      cy.intercept('/mock-backend/public/intro.md', {
+        statusCode: 404
+      })
+
+      cy.get(`iframe[data-cy="documentIframe"]`)
+        .should('not.exist')
     })
   })
 

--- a/src/components/intro-page/hooks/use-intro-page-content.ts
+++ b/src/components/intro-page/hooks/use-intro-page-content.ts
@@ -9,20 +9,15 @@ import { useTranslation } from 'react-i18next'
 import { fetchFrontPageContent } from '../requests'
 import { useCustomizeAssetsUrl } from '../../../hooks/common/use-customize-assets-url'
 
-const MARKDOWN_WHILE_LOADING = ':zzz: {message}'
-const MARKDOWN_IF_ERROR = ':::danger\n' +
-  '{message}\n' +
-  ':::'
-
-export const useIntroPageContent = (): string => {
+export const useIntroPageContent = (): string | undefined => {
   const { t } = useTranslation()
-  const [content, setContent] = useState<string>(() => MARKDOWN_WHILE_LOADING.replace('{message}', t('landing.intro.markdownWhileLoading')))
+  const [content, setContent] = useState<string | undefined>(undefined)
   const customizeAssetsUrl = useCustomizeAssetsUrl()
 
   useEffect(() => {
     fetchFrontPageContent(customizeAssetsUrl)
       .then((content) => setContent(content))
-      .catch(() => setContent(MARKDOWN_IF_ERROR.replace('{message}', t('landing.intro.markdownLoadingError'))))
+      .catch(() => setContent(undefined))
   }, [customizeAssetsUrl, t])
 
   return content

--- a/src/components/intro-page/intro-page.tsx
+++ b/src/components/intro-page/intro-page.tsx
@@ -22,33 +22,34 @@ import { WaitSpinner } from '../common/wait-spinner/wait-spinner'
 
 export const IntroPage: React.FC = () => {
   const introPageContent = useIntroPageContent()
-  const [showSpinner, setShowSpinner] = useState<boolean>(true)
+  const [rendererReady, setRendererReady] = useState<boolean>(true)
 
-  return (
-    <Fragment>
-      <div className={ 'flex-fill mt-3' }>
-        <h1 dir='auto' className={ 'align-items-center d-flex justify-content-center flex-column' }>
-          <HedgeDocLogoWithText logoType={ HedgeDocLogoType.COLOR_VERTICAL } size={ HedgeDocLogoSize.BIG }/>
-        </h1>
-        <p className="lead">
-          <Trans i18nKey="app.slogan"/>
-        </p>
-        <div className={ 'mb-5' }>
-          <Branding delimiter={ false }/>
-        </div>
-        <CoverButtons/>
-        <ShowIf condition={ showSpinner }>
-          <WaitSpinner/>
-        </ShowIf>
+  return <Fragment>
+    <div className={ 'flex-fill mt-3' }>
+      <h1 dir="auto" className={ 'align-items-center d-flex justify-content-center flex-column' }>
+        <HedgeDocLogoWithText logoType={ HedgeDocLogoType.COLOR_VERTICAL } size={ HedgeDocLogoSize.BIG }/>
+      </h1>
+      <p className="lead">
+        <Trans i18nKey="app.slogan"/>
+      </p>
+      <div className={ 'mb-5' }>
+        <Branding delimiter={ false }/>
+      </div>
+      <CoverButtons/>
+      <ShowIf condition={ !rendererReady && introPageContent !== undefined }>
+        <WaitSpinner/>
+      </ShowIf>
+      <ShowIf condition={ !!introPageContent }>
         <RenderIframe
           frameClasses={ 'w-100 overflow-y-hidden' }
-          markdownContent={ introPageContent }
+          markdownContent={ introPageContent as string }
           disableToc={ true }
-          onRendererReadyChange={ (rendererReady => setShowSpinner(!rendererReady)) }
+          onRendererReadyChange={ (rendererReady => setRendererReady(!rendererReady)) }
           rendererType={ RendererType.INTRO }
           forcedDarkMode={ true }/>
-        <hr className={ 'mb-5' }/>
-      </div>
-      <FeatureLinks/>
-    </Fragment>)
+      </ShowIf>
+      <hr className={ 'mb-5' }/>
+    </div>
+    <FeatureLinks/>
+  </Fragment>
 }

--- a/src/components/intro-page/intro-page.tsx
+++ b/src/components/intro-page/intro-page.tsx
@@ -24,32 +24,33 @@ export const IntroPage: React.FC = () => {
   const introPageContent = useIntroPageContent()
   const [rendererReady, setRendererReady] = useState<boolean>(true)
 
-  return <Fragment>
-    <div className={ 'flex-fill mt-3' }>
-      <h1 dir="auto" className={ 'align-items-center d-flex justify-content-center flex-column' }>
-        <HedgeDocLogoWithText logoType={ HedgeDocLogoType.COLOR_VERTICAL } size={ HedgeDocLogoSize.BIG }/>
-      </h1>
-      <p className="lead">
-        <Trans i18nKey="app.slogan"/>
-      </p>
-      <div className={ 'mb-5' }>
-        <Branding delimiter={ false }/>
+  return (
+    <Fragment>
+      <div className={ 'flex-fill mt-3' }>
+        <h1 dir="auto" className={ 'align-items-center d-flex justify-content-center flex-column' }>
+          <HedgeDocLogoWithText logoType={ HedgeDocLogoType.COLOR_VERTICAL } size={ HedgeDocLogoSize.BIG }/>
+        </h1>
+        <p className="lead">
+          <Trans i18nKey="app.slogan"/>
+        </p>
+        <div className={ 'mb-5' }>
+          <Branding delimiter={ false }/>
+        </div>
+        <CoverButtons/>
+        <ShowIf condition={ !rendererReady && introPageContent !== undefined }>
+          <WaitSpinner/>
+        </ShowIf>
+        <ShowIf condition={ !!introPageContent }>
+          <RenderIframe
+            frameClasses={ 'w-100 overflow-y-hidden' }
+            markdownContent={ introPageContent as string }
+            disableToc={ true }
+            onRendererReadyChange={ (rendererReady => setRendererReady(!rendererReady)) }
+            rendererType={ RendererType.INTRO }
+            forcedDarkMode={ true }/>
+        </ShowIf>
+        <hr className={ 'mb-5' }/>
       </div>
-      <CoverButtons/>
-      <ShowIf condition={ !rendererReady && introPageContent !== undefined }>
-        <WaitSpinner/>
-      </ShowIf>
-      <ShowIf condition={ !!introPageContent }>
-        <RenderIframe
-          frameClasses={ 'w-100 overflow-y-hidden' }
-          markdownContent={ introPageContent as string }
-          disableToc={ true }
-          onRendererReadyChange={ (rendererReady => setRendererReady(!rendererReady)) }
-          rendererType={ RendererType.INTRO }
-          forcedDarkMode={ true }/>
-      </ShowIf>
-      <hr className={ 'mb-5' }/>
-    </div>
-    <FeatureLinks/>
-  </Fragment>
+      <FeatureLinks/>
+    </Fragment>)
 }


### PR DESCRIPTION
### Component/Part
Intro page

### Description
This PR changes the behaviour of the intro page. If no intro could be fetched then the output should be blank.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
