### PR TITLE
Fix spinner visibility on intro-page

### DIFF
--- a/src/components/intro-page/intro-page.tsx
+++ b/src/components/intro-page/intro-page.tsx
@@ -45,7 +45,7 @@ export const IntroPage: React.FC = () => {
             frameClasses={ 'w-100 overflow-y-hidden' }
             markdownContent={ introPageContent as string }
             disableToc={ true }
-            onRendererReadyChange={ (rendererReady => setRendererReady(!rendererReady)) }
+            onRendererReadyChange={ setRendererReady }
             rendererType={ RendererType.INTRO }
             forcedDarkMode={ true }/>
         </ShowIf>


### PR DESCRIPTION
### Component/Part
Intro-Page

### Desciption
The spinner on the intro page doesn't hide after the page load. This PR fixes this bug.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
