### PR TITLE
Fix task list checkboxes for numbered lists

### DIFF
--- a/cypress/integration/taskLists.spec.ts
+++ b/cypress/integration/taskLists.spec.ts
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+const TEST_STRING_UNCHECKED = '- [ ] abc\n\n* [ ] abc\n\n+ [ ] abc\n\n1. [ ] abc\n\n10. [ ] abc'
+const TEST_STRING_CHECKED_LOWER = '- [x] abc\n\n* [x] abc\n\n+ [x] abc\n\n1. [x] abc\n\n10. [x] abc'
+const TEST_STRING_CHECKED_UPPER = '- [X] abc\n\n* [X] abc\n\n+ [X] abc\n\n1. [X] abc\n\n10. [X] abc'
+const TEST_STRING_INVALID = '- [Y] abc\n\n* [  ] abc\n\n+ [-] abc\n\n1. [.] abc\n\n10. [] abc'
+
+describe('Task lists ', () => {
+  beforeEach(() => {
+    cy.visitTestEditor()
+  })
+
+  describe('render with checkboxes ', () => {
+    it('when unchecked', () => {
+      cy.codemirrorFill(TEST_STRING_UNCHECKED)
+      cy.getMarkdownBody()
+        .find('input[type=checkbox]')
+        .should('have.length', 5)
+    })
+
+    it('when checked lowercase', () => {
+      cy.codemirrorFill(TEST_STRING_CHECKED_LOWER)
+      cy.getMarkdownBody()
+        .find('input[type=checkbox]')
+        .should('have.length', 5)
+    })
+
+    it('when checked uppercase', () => {
+      cy.codemirrorFill(TEST_STRING_CHECKED_UPPER)
+      cy.getMarkdownBody()
+        .find('input[type=checkbox]')
+        .should('have.length', 5)
+    })
+  })
+
+  it('do not render as checkboxes when invalid', () => {
+    cy.codemirrorFill(TEST_STRING_INVALID)
+    cy.getMarkdownBody()
+      .find('input[type=checkbox]')
+      .should('have.length', 0)
+  })
+
+  describe('are clickable and change the markdown source ', () => {
+    it('from unchecked to checked', () => {
+      cy.codemirrorFill(TEST_STRING_UNCHECKED)
+      cy.getMarkdownBody()
+        .find('input[type=checkbox]')
+        .each(box => {
+          box.trigger('click')
+        })
+      cy.get('.CodeMirror-line > span')
+        .should('exist')
+        .should('contain.text', '[x]')
+        .should('not.contain.text', '[ ]')
+    })
+
+    it('from checked (lowercase) to unchecked', () => {
+      cy.codemirrorFill(TEST_STRING_CHECKED_LOWER)
+      cy.getMarkdownBody()
+        .find('input[type=checkbox]')
+        .each(box => {
+          box.trigger('click')
+        })
+      cy.get('.CodeMirror-line > span')
+        .should('exist')
+        .should('contain.text', '[ ]')
+        .should('not.contain.text', '[x]')
+    })
+
+    it('from checked (uppercase) to unchecked', () => {
+      cy.codemirrorFill(TEST_STRING_CHECKED_UPPER)
+      cy.getMarkdownBody()
+        .find('input[type=checkbox]')
+        .each(box => {
+          box.trigger('click')
+        })
+      cy.get('.CodeMirror-line > span')
+        .should('exist')
+        .should('contain.text', '[ ]')
+        .should('not.contain.text', '[X]')
+    })
+  })
+})

--- a/cypress/integration/taskLists.spec.ts
+++ b/cypress/integration/taskLists.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-const TEST_STRING_UNCHECKED = '- [ ] abc\n\n* [ ] abc\n\n+ [ ] abc\n\n1. [ ] abc\n\n10. [ ] abc'
-const TEST_STRING_CHECKED_LOWER = '- [x] abc\n\n* [x] abc\n\n+ [x] abc\n\n1. [x] abc\n\n10. [x] abc'
-const TEST_STRING_CHECKED_UPPER = '- [X] abc\n\n* [X] abc\n\n+ [X] abc\n\n1. [X] abc\n\n10. [X] abc'
-const TEST_STRING_INVALID = '- [Y] abc\n\n* [  ] abc\n\n+ [-] abc\n\n1. [.] abc\n\n10. [] abc'
+const TEST_STRING_UNCHECKED = '- [ ] abc\n\n* [ ] abc\n\n+ [ ] abc\n\n1. [ ] abc\n\n10. [ ] abc\n\n5) [ ] abc'
+const TEST_STRING_CHECKED_LOWER = '- [x] abc\n\n* [x] abc\n\n+ [x] abc\n\n1. [x] abc\n\n10. [x] abc\n\n5) [x] abc'
+const TEST_STRING_CHECKED_UPPER = '- [X] abc\n\n* [X] abc\n\n+ [X] abc\n\n1. [X] abc\n\n10. [X] abc\n\n5) [X] abc'
+const TEST_STRING_INVALID = '- [Y] abc\n\n* [  ] abc\n\n+ [-] abc\n\n1. [.] abc\n\n10. [] abc\n\n5) [-] abc'
 
 describe('Task lists ', () => {
   beforeEach(() => {
@@ -19,21 +19,21 @@ describe('Task lists ', () => {
       cy.codemirrorFill(TEST_STRING_UNCHECKED)
       cy.getMarkdownBody()
         .find('input[type=checkbox]')
-        .should('have.length', 5)
+        .should('have.length', 6)
     })
 
     it('when checked lowercase', () => {
       cy.codemirrorFill(TEST_STRING_CHECKED_LOWER)
       cy.getMarkdownBody()
         .find('input[type=checkbox]')
-        .should('have.length', 5)
+        .should('have.length', 6)
     })
 
     it('when checked uppercase', () => {
       cy.codemirrorFill(TEST_STRING_CHECKED_UPPER)
       cy.getMarkdownBody()
         .find('input[type=checkbox]')
-        .should('have.length', 5)
+        .should('have.length', 6)
     })
   })
 

--- a/src/redux/note-details/reducers.ts
+++ b/src/redux/note-details/reducers.ts
@@ -87,7 +87,7 @@ export const NoteDetailsReducer: Reducer<NoteDetails, NoteDetailsAction> = (stat
   }
 }
 
-const TASK_REGEX = /(\s*(?:[-*+]|\d+\.) )(\[[ xX]])( .*)/
+const TASK_REGEX = /(\s*(?:[-*+]|\d+[.)]) )(\[[ xX]])( .*)/
 const setCheckboxInMarkdownContent = (markdownContent: string, lineInMarkdown: number, checked: boolean): string => {
   const lines = markdownContent.split('\n')
   const results = TASK_REGEX.exec(lines[lineInMarkdown])

--- a/src/redux/note-details/reducers.ts
+++ b/src/redux/note-details/reducers.ts
@@ -87,7 +87,7 @@ export const NoteDetailsReducer: Reducer<NoteDetails, NoteDetailsAction> = (stat
   }
 }
 
-const TASK_REGEX = /(\s*[-*] )(\[[ xX]])( .*)/
+const TASK_REGEX = /(\s*(?:[-*+]|\d+\.) )(\[[ xX]])( .*)/
 const setCheckboxInMarkdownContent = (markdownContent: string, lineInMarkdown: number, checked: boolean): string => {
   const lines = markdownContent.split('\n')
   const results = TASK_REGEX.exec(lines[lineInMarkdown])


### PR DESCRIPTION
### Component/Part
Redux method for updating the checkbox state of a line

### Description
This PR fixes the regex that is used to identify the `[ ]` checkbox part when updating the markdown content for a clicked todo-list item. The previous regex could only detect todo-list items that start with a `-` or `*`. But `+` is a valid unordered list bullet point as well and numbered lists should also be supported.

This PR changes the regex to reflect this and adds tests for the todo-list feature.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
Fixes hedgedoc/hedgedoc#1220
