### PR TITLE
Replace bash dependency with nodejs script

### DIFF
--- a/check-build-env-vars.js
+++ b/check-build-env-vars.js
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+if (!process.env.REACT_APP_BACKEND_BASE_URL) {
+  console.error("==============\nREACT_APP_BACKEND_BASE_URL not set.\n  Use this task only if you want to create a production build with a real backend. Otherwise use build:mock\n==============");
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "serve:build": "http-server build/ -s -p 3001 -P \"http://localhost:3001?\"",
     "build:test": "cross-env REACT_APP_TEST_MODE=true craco build",
     "build:mock": "cross-env craco build",
-    "build:production": "bash -c \"[[ -v REACT_APP_BACKEND_BASE_URL ]]\" && (cross-env craco build) || (echo -e '\n==============\nREACT_APP_BACKEND_BASE_URL not set.\nUse this task only if you want to create a production build with a real backend. Otherwise use build:mock\n==============\n'; exit 1)",
+    "build:production": "(cross-env node check-build-env-vars.js) && (cross-env craco build)",
     "analyze": "cross-env ANALYZE=true yarn build:mock",
     "test": "craco test",
     "lint": "eslint --max-warnings=0 --ext .ts,.tsx src",


### PR DESCRIPTION
### Component/Part
Build environment

### Description
This PR replaces the bash script in the `build:production` task with a js file. This eliminates bash as build dependency.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
