### PR TITLE
Replace deprecated highlight.js syntax

### DIFF
--- a/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.tsx
+++ b/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.tsx
@@ -42,7 +42,7 @@ export const HighlightedCode: React.FC<HighlightedCodeProps> = ({ code, language
     import(/* webpackChunkName: "highlight.js" */ '../../../../common/hljs/hljs').then((hljs) => {
       const languageSupported = (lang: string) => hljs.default.listLanguages()
                                                       .includes(lang)
-      const unreplacedCode = !!language && languageSupported(language) ? hljs.default.highlight(language, code).value : escapeHtml(code)
+      const unreplacedCode = !!language && languageSupported(language) ? hljs.default.highlight(code, { language }).value : escapeHtml(code)
       const replacedDom = replaceCode(unreplacedCode)
         .map((line, index) => (
           <Fragment key={ index }>


### PR DESCRIPTION
### Component/Part
markdown renderer -> code highlighting

### Description
highlight.js 11.0.0 deprecated the `highlight()` call parameters we used. This PR changes the call to the new signature to avoid future breakings.

See also: https://github.com/highlightjs/highlight.js/blob/main/CHANGES.md#version-1100

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
#1292
