### PR TITLE
Fix splitter

### DIFF
--- a/src/components/editor-page/editor-page.tsx
+++ b/src/components/editor-page/editor-page.tsx
@@ -99,11 +99,11 @@ export const EditorPage: React.FC = () => {
   const leftPane = useMemo(
     () => (
       <EditorPane
-        onContentChange={setNoteMarkdownContent}
-        content={markdownContent}
-        scrollState={scrollState.editorScrollState}
-        onScroll={onEditorScroll}
-        onMakeScrollSource={setEditorToScrollSource}
+        onContentChange={ setNoteMarkdownContent }
+        content={ markdownContent }
+        scrollState={ scrollState.editorScrollState }
+        onScroll={ onEditorScroll }
+        onMakeScrollSource={ setEditorToScrollSource }
       />
     ),
     [markdownContent, onEditorScroll, scrollState.editorScrollState, setEditorToScrollSource]
@@ -112,15 +112,15 @@ export const EditorPage: React.FC = () => {
   const rightPane = useMemo(
     () => (
       <RenderIframe
-        frameClasses={'h-100 w-100'}
-        markdownContent={markdownContent}
-        onMakeScrollSource={setRendererToScrollSource}
-        onFirstHeadingChange={updateNoteTitleByFirstHeading}
-        onTaskCheckedChange={SetCheckboxInMarkdownContent}
-        onFrontmatterChange={setNoteFrontmatter}
-        onScroll={onMarkdownRendererScroll}
-        scrollState={scrollState.rendererScrollState}
-        rendererType={RendererType.DOCUMENT}
+        frameClasses={ 'h-100 w-100' }
+        markdownContent={ markdownContent }
+        onMakeScrollSource={ setRendererToScrollSource }
+        onFirstHeadingChange={ updateNoteTitleByFirstHeading }
+        onTaskCheckedChange={ SetCheckboxInMarkdownContent }
+        onFrontmatterChange={ setNoteFrontmatter }
+        onScroll={ onMarkdownRendererScroll }
+        scrollState={ scrollState.rendererScrollState }
+        rendererType={ RendererType.DOCUMENT }
       />
     ),
     [markdownContent, onMarkdownRendererScroll, scrollState.rendererScrollState, setRendererToScrollSource]
@@ -128,24 +128,24 @@ export const EditorPage: React.FC = () => {
 
   return (
     <IframeCommunicatorContextProvider>
-      <UiNotifications />
-      <MotdBanner />
-      <div className={'d-flex flex-column vh-100'}>
-        <AppBar mode={AppBarMode.EDITOR} />
-        <div className={'container'}>
-          <ErrorWhileLoadingNoteAlert show={error} />
-          <LoadingNoteAlert show={loading} />
+      <UiNotifications/>
+      <MotdBanner/>
+      <div className={ 'd-flex flex-column vh-100' }>
+        <AppBar mode={ AppBarMode.EDITOR }/>
+        <div className={ 'container' }>
+          <ErrorWhileLoadingNoteAlert show={ error }/>
+          <LoadingNoteAlert show={ loading }/>
         </div>
-        <ShowIf condition={!error && !loading}>
-          <div className={'flex-fill d-flex h-100 w-100 overflow-hidden flex-row'}>
+        <ShowIf condition={ !error && !loading }>
+          <div className={ 'flex-fill d-flex h-100 w-100 overflow-hidden flex-row' }>
             <Splitter
-              showLeft={editorMode === EditorMode.EDITOR || editorMode === EditorMode.BOTH}
-              left={leftPane}
-              showRight={editorMode === EditorMode.PREVIEW || editorMode === EditorMode.BOTH}
+              showLeft={ editorMode === EditorMode.EDITOR || editorMode === EditorMode.BOTH }
+              left={ leftPane }
+              showRight={ editorMode === EditorMode.PREVIEW || editorMode === EditorMode.BOTH }
               right={ rightPane }
               additionalContainerClassName={ 'overflow-hidden' }
             />
-            <Sidebar />
+            <Sidebar/>
           </div>
         </ShowIf>
       </div>

--- a/src/components/editor-page/editor-page.tsx
+++ b/src/components/editor-page/editor-page.tsx
@@ -12,7 +12,7 @@ import { useDocumentTitleWithNoteTitle } from '../../hooks/common/use-document-t
 import { useNoteMarkdownContent } from '../../hooks/common/use-note-markdown-content'
 import { ApplicationState } from '../../redux'
 import {
-  SetCheckboxInMarkdownContent,
+  setCheckboxInMarkdownContent,
   setNoteFrontmatter,
   setNoteMarkdownContent,
   updateNoteTitleByFirstHeading
@@ -116,7 +116,7 @@ export const EditorPage: React.FC = () => {
         markdownContent={markdownContent}
         onMakeScrollSource={setRendererToScrollSource}
         onFirstHeadingChange={updateNoteTitleByFirstHeading}
-        onTaskCheckedChange={SetCheckboxInMarkdownContent}
+        onTaskCheckedChange={setCheckboxInMarkdownContent}
         onFrontmatterChange={setNoteFrontmatter}
         onScroll={onMarkdownRendererScroll}
         scrollState={scrollState.rendererScrollState}

--- a/src/components/editor-page/editor-page.tsx
+++ b/src/components/editor-page/editor-page.tsx
@@ -99,11 +99,11 @@ export const EditorPage: React.FC = () => {
   const leftPane = useMemo(
     () => (
       <EditorPane
-        onContentChange={ setNoteMarkdownContent }
-        content={ markdownContent }
-        scrollState={ scrollState.editorScrollState }
-        onScroll={ onEditorScroll }
-        onMakeScrollSource={ setEditorToScrollSource }
+        onContentChange={setNoteMarkdownContent}
+        content={markdownContent}
+        scrollState={scrollState.editorScrollState}
+        onScroll={onEditorScroll}
+        onMakeScrollSource={setEditorToScrollSource}
       />
     ),
     [markdownContent, onEditorScroll, scrollState.editorScrollState, setEditorToScrollSource]
@@ -112,15 +112,15 @@ export const EditorPage: React.FC = () => {
   const rightPane = useMemo(
     () => (
       <RenderIframe
-        frameClasses={ 'h-100 w-100' }
-        markdownContent={ markdownContent }
-        onMakeScrollSource={ setRendererToScrollSource }
-        onFirstHeadingChange={ updateNoteTitleByFirstHeading }
-        onTaskCheckedChange={ SetCheckboxInMarkdownContent }
-        onFrontmatterChange={ setNoteFrontmatter }
-        onScroll={ onMarkdownRendererScroll }
-        scrollState={ scrollState.rendererScrollState }
-        rendererType={ RendererType.DOCUMENT }
+        frameClasses={'h-100 w-100'}
+        markdownContent={markdownContent}
+        onMakeScrollSource={setRendererToScrollSource}
+        onFirstHeadingChange={updateNoteTitleByFirstHeading}
+        onTaskCheckedChange={SetCheckboxInMarkdownContent}
+        onFrontmatterChange={setNoteFrontmatter}
+        onScroll={onMarkdownRendererScroll}
+        scrollState={scrollState.rendererScrollState}
+        rendererType={RendererType.DOCUMENT}
       />
     ),
     [markdownContent, onMarkdownRendererScroll, scrollState.rendererScrollState, setRendererToScrollSource]
@@ -128,24 +128,24 @@ export const EditorPage: React.FC = () => {
 
   return (
     <IframeCommunicatorContextProvider>
-      <UiNotifications/>
-      <MotdBanner/>
-      <div className={ 'd-flex flex-column vh-100' }>
-        <AppBar mode={ AppBarMode.EDITOR }/>
-        <div className={ 'container' }>
-          <ErrorWhileLoadingNoteAlert show={ error }/>
-          <LoadingNoteAlert show={ loading }/>
+      <UiNotifications />
+      <MotdBanner />
+      <div className={'d-flex flex-column vh-100'}>
+        <AppBar mode={AppBarMode.EDITOR} />
+        <div className={'container'}>
+          <ErrorWhileLoadingNoteAlert show={error} />
+          <LoadingNoteAlert show={loading} />
         </div>
-        <ShowIf condition={ !error && !loading }>
-          <div className={ 'flex-fill d-flex h-100 w-100 overflow-hidden flex-row' }>
+        <ShowIf condition={!error && !loading}>
+          <div className={'flex-fill d-flex h-100 w-100 overflow-hidden flex-row'}>
             <Splitter
-              showLeft={ editorMode === EditorMode.EDITOR || editorMode === EditorMode.BOTH }
-              left={ leftPane }
-              showRight={ editorMode === EditorMode.PREVIEW || editorMode === EditorMode.BOTH }
-              right={ rightPane }
-              additionalContainerClassName={ 'overflow-hidden' }
+              showLeft={editorMode === EditorMode.EDITOR || editorMode === EditorMode.BOTH}
+              left={leftPane}
+              showRight={editorMode === EditorMode.PREVIEW || editorMode === EditorMode.BOTH}
+              right={rightPane}
+              additionalContainerClassName={'overflow-hidden'}
             />
-            <Sidebar/>
+            <Sidebar />
           </div>
         </ShowIf>
       </div>

--- a/src/components/editor-page/editor-page.tsx
+++ b/src/components/editor-page/editor-page.tsx
@@ -142,8 +142,8 @@ export const EditorPage: React.FC = () => {
               showLeft={editorMode === EditorMode.EDITOR || editorMode === EditorMode.BOTH}
               left={leftPane}
               showRight={editorMode === EditorMode.PREVIEW || editorMode === EditorMode.BOTH}
-              right={rightPane}
-              containerClassName={'overflow-hidden'}
+              right={ rightPane }
+              additionalContainerClassName={ 'overflow-hidden' }
             />
             <Sidebar />
           </div>

--- a/src/components/editor-page/splitter/splitter.scss
+++ b/src/components/editor-page/splitter/splitter.scss
@@ -6,12 +6,7 @@
 
 .splitter {
   &.left {
-    //flex: 0 1 100%;
     min-width: 200px;
-  }
-
-  &.right {
-   // flex: 1 0 200px;
   }
 
   &.separator {

--- a/src/components/editor-page/splitter/splitter.scss
+++ b/src/components/editor-page/splitter/splitter.scss
@@ -6,12 +6,12 @@
 
 .splitter {
   &.left {
-    flex: 0 1 100%;
+    //flex: 0 1 100%;
     min-width: 200px;
   }
 
   &.right {
-    flex: 1 0 200px;
+   // flex: 1 0 200px;
   }
 
   &.separator {

--- a/src/components/editor-page/splitter/splitter.tsx
+++ b/src/components/editor-page/splitter/splitter.tsx
@@ -12,7 +12,7 @@ import './splitter.scss'
 export interface SplitterProps {
   left: ReactElement
   right: ReactElement
-  containerClassName?: string
+  additionalContainerClassName?: string
   showLeft: boolean
   showRight: boolean
 }
@@ -44,7 +44,17 @@ const extractHorizontalPosition = (moveEvent: MouseEvent | TouchEvent): number =
   }
 }
 
-export const Splitter: React.FC<SplitterProps> = ({ containerClassName, left, right, showLeft, showRight }) => {
+/**
+ * Creates a Left/Right splitter react component.
+ *
+ * @param additionalContainerClassName css classes that are added to the split container.
+ * @param left the react component that should be shown on the left side.
+ * @param right the react component that should be shown on the right side.
+ * @param showLeft defines if the left component should be shown or hidden. Settings this prop will hide the component with css.
+ * @param showRight defines if the right component should be shown or hidden. Settings this prop will hide the component with css.
+ * @return the created component
+ */
+export const Splitter: React.FC<SplitterProps> = ({ additionalContainerClassName, left, right, showLeft, showRight }) => {
   const [relativeSplitValue, setRelativeSplitValue] = useState(50)
   const cappedRelativeSplitValue = Math.max(0, Math.min(100, showRight ? relativeSplitValue : 100))
   const resizingInProgress = useRef(false)
@@ -110,9 +120,7 @@ export const Splitter: React.FC<SplitterProps> = ({ containerClassName, left, ri
   }, [resizingInProgress, onMove, onStopResizing])
 
   return (
-    <div
-      ref={ splitContainer }
-      className={ `flex-fill flex-row d-flex ${ containerClassName || '' }` }>
+    <div ref={ splitContainer } className={ `flex-fill flex-row d-flex ${ additionalContainerClassName || '' }` }>
       <div className={ `splitter left ${ !showLeft ? 'd-none' : '' }` }
            style={ { width: `calc(${ cappedRelativeSplitValue }% - 5px)` } }>
         { left }
@@ -123,7 +131,9 @@ export const Splitter: React.FC<SplitterProps> = ({ containerClassName, left, ri
         </div>
       </ShowIf>
       <div className={ `splitter right ${ !showRight ? 'd-none' : '' }` }
-           style={ { width: `calc(100% - ${ cappedRelativeSplitValue }%)` } }>{ right }</div>
+           style={ { width: `calc(100% - ${ cappedRelativeSplitValue }%)` } }>
+        { right }
+      </div>
     </div>
   )
 }

--- a/src/components/editor-page/splitter/splitter.tsx
+++ b/src/components/editor-page/splitter/splitter.tsx
@@ -67,7 +67,7 @@ export const Splitter: React.FC<SplitterProps> = ({ containerClassName, left, ri
       onTouchEnd={stopResizing}
       onMouseMove={onMouseMove}
       onTouchMove={onTouchMove}>
-      <div className={`splitter left ${!showLeft ? 'd-none' : ''}`} style={{ flexBasis: `calc(${realSplit}% - 5px)` }}>
+      <div className={`splitter left ${!showLeft ? 'd-none' : ''}`} style={{ width: `calc(${realSplit}% - 5px)` }}>
         {left}
       </div>
       <ShowIf condition={showLeft && showRight}>
@@ -75,7 +75,7 @@ export const Splitter: React.FC<SplitterProps> = ({ containerClassName, left, ri
           <SplitDivider onGrab={onGrab} />
         </div>
       </ShowIf>
-      <div className={`splitter right ${!showRight ? 'd-none' : ''}`}>{right}</div>
+      <div className={`splitter right ${!showRight ? 'd-none' : ''}`} style={{ width: `calc(100% - ${realSplit}%)` }}>{right}</div>
     </div>
   )
 }

--- a/src/components/editor-page/splitter/splitter.tsx
+++ b/src/components/editor-page/splitter/splitter.tsx
@@ -110,18 +110,18 @@ export const Splitter: React.FC<SplitterProps> = ({
   useEffect(() => {
     const moveHandler = onMove
     const stopResizeHandler = onStopResizing
-    document.body.addEventListener('touchmove', moveHandler)
-    document.body.addEventListener('mousemove', moveHandler)
-    document.body.addEventListener('touchcancel', stopResizeHandler)
-    document.body.addEventListener('touchend', stopResizeHandler)
-    document.body.addEventListener('mouseup', stopResizeHandler)
+    window.addEventListener('touchmove', moveHandler)
+    window.addEventListener('mousemove', moveHandler)
+    window.addEventListener('touchcancel', stopResizeHandler)
+    window.addEventListener('touchend', stopResizeHandler)
+    window.addEventListener('mouseup', stopResizeHandler)
 
     return () => {
-      document.body.removeEventListener('touchmove', moveHandler)
-      document.body.removeEventListener('mousemove', moveHandler)
-      document.body.removeEventListener('touchcancel', stopResizeHandler)
-      document.body.removeEventListener('touchend', stopResizeHandler)
-      document.body.removeEventListener('mouseup', stopResizeHandler)
+      window.removeEventListener('touchmove', moveHandler)
+      window.removeEventListener('mousemove', moveHandler)
+      window.removeEventListener('touchcancel', stopResizeHandler)
+      window.removeEventListener('touchend', stopResizeHandler)
+      window.removeEventListener('mouseup', stopResizeHandler)
     }
   }, [resizingInProgress, onMove, onStopResizing])
 

--- a/src/components/editor-page/splitter/splitter.tsx
+++ b/src/components/editor-page/splitter/splitter.tsx
@@ -54,7 +54,13 @@ const extractHorizontalPosition = (moveEvent: MouseEvent | TouchEvent): number =
  * @param showRight defines if the right component should be shown or hidden. Settings this prop will hide the component with css.
  * @return the created component
  */
-export const Splitter: React.FC<SplitterProps> = ({ additionalContainerClassName, left, right, showLeft, showRight }) => {
+export const Splitter: React.FC<SplitterProps> = ({
+  additionalContainerClassName,
+  left,
+  right,
+  showLeft,
+  showRight
+}) => {
   const [relativeSplitValue, setRelativeSplitValue] = useState(50)
   const cappedRelativeSplitValue = Math.max(0, Math.min(100, showRight ? relativeSplitValue : 100))
   const resizingInProgress = useRef(false)
@@ -120,19 +126,21 @@ export const Splitter: React.FC<SplitterProps> = ({ additionalContainerClassName
   }, [resizingInProgress, onMove, onStopResizing])
 
   return (
-    <div ref={ splitContainer } className={ `flex-fill flex-row d-flex ${ additionalContainerClassName || '' }` }>
-      <div className={ `splitter left ${ !showLeft ? 'd-none' : '' }` }
-           style={ { width: `calc(${ cappedRelativeSplitValue }% - 5px)` } }>
-        { left }
+    <div ref={splitContainer} className={`flex-fill flex-row d-flex ${additionalContainerClassName || ''}`}>
+      <div
+        className={`splitter left ${!showLeft ? 'd-none' : ''}`}
+        style={{ width: `calc(${cappedRelativeSplitValue}% - 5px)` }}>
+        {left}
       </div>
-      <ShowIf condition={ showLeft && showRight }>
-        <div className="splitter separator">
-          <SplitDivider onGrab={ onStartResizing }/>
+      <ShowIf condition={showLeft && showRight}>
+        <div className='splitter separator'>
+          <SplitDivider onGrab={onStartResizing} />
         </div>
       </ShowIf>
-      <div className={ `splitter right ${ !showRight ? 'd-none' : '' }` }
-           style={ { width: `calc(100% - ${ cappedRelativeSplitValue }%)` } }>
-        { right }
+      <div
+        className={`splitter right ${!showRight ? 'd-none' : ''}`}
+        style={{ width: `calc(100% - ${cappedRelativeSplitValue}%)` }}>
+        {right}
       </div>
     </div>
   )

--- a/src/components/markdown-renderer/markdown-renderer.scss
+++ b/src/components/markdown-renderer/markdown-renderer.scss
@@ -11,6 +11,17 @@
   font-family: 'Source Sans Pro', "Twemoji", sans-serif;
   word-break: break-word;
 
+  .svg-container {
+    overflow-x: auto;
+    width: 100%;
+    display: inline-block;
+    text-align: center;
+
+    svg {
+      max-width: 100%;
+    }
+  }
+
   .alert > p, .alert > ul {
     margin-bottom: 0;
   }

--- a/src/components/markdown-renderer/replace-components/abc/abc-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/abc/abc-frame.tsx
@@ -28,5 +28,5 @@ export const AbcFrame: React.FC<AbcFrameProps> = ({ code }) => {
       })
   }, [code])
 
-  return <div ref={container} className={'abcjs-score bg-white text-black text-center overflow-x-auto'} />
+  return <div ref={ container } className={ 'abcjs-score bg-white text-black svg-container' }/>
 }

--- a/src/components/markdown-renderer/replace-components/abc/abc-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/abc/abc-frame.tsx
@@ -28,5 +28,5 @@ export const AbcFrame: React.FC<AbcFrameProps> = ({ code }) => {
       })
   }, [code])
 
-  return <div ref={ container } className={ 'abcjs-score bg-white text-black svg-container' }/>
+  return <div ref={container} className={'abcjs-score bg-white text-black svg-container'} />
 }

--- a/src/components/markdown-renderer/replace-components/graphviz/graphviz-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/graphviz/graphviz-frame.tsx
@@ -23,8 +23,7 @@ export const GraphvizFrame: React.FC<GraphvizFrameProps> = ({ code }) => {
     }
     setError(error)
     console.error(error)
-    container.current.querySelectorAll('svg')
-             .forEach((child) => child.remove())
+    container.current.querySelectorAll('svg').forEach((child) => child.remove())
   }, [])
 
   const frontendBaseUrl = useFrontendBaseUrl()
@@ -37,7 +36,7 @@ export const GraphvizFrame: React.FC<GraphvizFrameProps> = ({ code }) => {
 
     import(/* webpackChunkName: "d3-graphviz" */ '@hpcc-js/wasm')
       .then((wasmPlugin) => {
-        wasmPlugin.wasmFolder(`${ frontendBaseUrl }/static/js`)
+        wasmPlugin.wasmFolder(`${frontendBaseUrl}/static/js`)
       })
       .then(() => import(/* webpackChunkName: "d3-graphviz" */ 'd3-graphviz'))
       .then((graphvizImport) => {
@@ -61,10 +60,10 @@ export const GraphvizFrame: React.FC<GraphvizFrameProps> = ({ code }) => {
 
   return (
     <Fragment>
-      <ShowIf condition={ !!error }>
-        <Alert variant={ 'warning' }>{ error }</Alert>
+      <ShowIf condition={!!error}>
+        <Alert variant={'warning'}>{error}</Alert>
       </ShowIf>
-      <div className={ 'svg-container' } data-cy={ 'graphviz' } ref={ container }/>
+      <div className={'svg-container'} data-cy={'graphviz'} ref={container} />
     </Fragment>
   )
 }

--- a/src/components/markdown-renderer/replace-components/graphviz/graphviz-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/graphviz/graphviz-frame.tsx
@@ -60,10 +60,10 @@ export const GraphvizFrame: React.FC<GraphvizFrameProps> = ({ code }) => {
 
   return (
     <Fragment>
-      <ShowIf condition={!!error}>
-        <Alert variant={'warning'}>{error}</Alert>
+      <ShowIf condition={ !!error }>
+        <Alert variant={ 'warning' }>{ error }</Alert>
       </ShowIf>
-      <div className={'text-center overflow-x-auto'} data-cy={'graphviz'} ref={container} />
+      <div className={ 'svg-container' } data-cy={ 'graphviz' } ref={ container }/>
     </Fragment>
   )
 }

--- a/src/components/markdown-renderer/replace-components/graphviz/graphviz-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/graphviz/graphviz-frame.tsx
@@ -23,7 +23,8 @@ export const GraphvizFrame: React.FC<GraphvizFrameProps> = ({ code }) => {
     }
     setError(error)
     console.error(error)
-    container.current.querySelectorAll('svg').forEach((child) => child.remove())
+    container.current.querySelectorAll('svg')
+             .forEach((child) => child.remove())
   }, [])
 
   const frontendBaseUrl = useFrontendBaseUrl()
@@ -36,7 +37,7 @@ export const GraphvizFrame: React.FC<GraphvizFrameProps> = ({ code }) => {
 
     import(/* webpackChunkName: "d3-graphviz" */ '@hpcc-js/wasm')
       .then((wasmPlugin) => {
-        wasmPlugin.wasmFolder(`${frontendBaseUrl}/static/js`)
+        wasmPlugin.wasmFolder(`${ frontendBaseUrl }/static/js`)
       })
       .then(() => import(/* webpackChunkName: "d3-graphviz" */ 'd3-graphviz'))
       .then((graphvizImport) => {

--- a/src/components/markdown-renderer/replace-components/markmap/markmap-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/markmap/markmap-frame.tsx
@@ -64,12 +64,12 @@ export const MarkmapFrame: React.FC<MarkmapFrameProps> = ({ code }) => {
 
   return (
     <div data-cy={'markmap'}>
-      <div className={'text-center'} ref={diagramContainer} />
-      <div className={'text-right button-inside'}>
+      <div className={ 'svg-container' } ref={ diagramContainer }/>
+      <div className={ 'text-right button-inside' }>
         <LockButton
-          locked={disablePanAndZoom}
-          onLockedChanged={(newState) => setDisablePanAndZoom(newState)}
-          title={disablePanAndZoom ? t('renderer.markmap.locked') : t('renderer.markmap.unlocked')}
+          locked={ disablePanAndZoom }
+          onLockedChanged={ (newState) => setDisablePanAndZoom(newState) }
+          title={ disablePanAndZoom ? t('renderer.markmap.locked') : t('renderer.markmap.unlocked') }
         />
       </div>
     </div>

--- a/src/components/markdown-renderer/replace-components/markmap/markmap-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/markmap/markmap-frame.tsx
@@ -50,7 +50,8 @@ export const MarkmapFrame: React.FC<MarkmapFrameProps> = ({ code }) => {
         try {
           const svg: SVGSVGElement = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
           svg.setAttribute('width', '100%')
-          actualContainer.querySelectorAll('svg').forEach((child) => child.remove())
+          actualContainer.querySelectorAll('svg')
+                         .forEach((child) => child.remove())
           actualContainer.appendChild(svg)
           markmapLoader(svg, code)
         } catch (error) {
@@ -63,7 +64,7 @@ export const MarkmapFrame: React.FC<MarkmapFrameProps> = ({ code }) => {
   }, [code])
 
   return (
-    <div data-cy={'markmap'}>
+    <div data-cy={ 'markmap' }>
       <div className={ 'svg-container' } ref={ diagramContainer }/>
       <div className={ 'text-right button-inside' }>
         <LockButton

--- a/src/components/markdown-renderer/replace-components/markmap/markmap-frame.tsx
+++ b/src/components/markdown-renderer/replace-components/markmap/markmap-frame.tsx
@@ -50,8 +50,7 @@ export const MarkmapFrame: React.FC<MarkmapFrameProps> = ({ code }) => {
         try {
           const svg: SVGSVGElement = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
           svg.setAttribute('width', '100%')
-          actualContainer.querySelectorAll('svg')
-                         .forEach((child) => child.remove())
+          actualContainer.querySelectorAll('svg').forEach((child) => child.remove())
           actualContainer.appendChild(svg)
           markmapLoader(svg, code)
         } catch (error) {
@@ -64,13 +63,13 @@ export const MarkmapFrame: React.FC<MarkmapFrameProps> = ({ code }) => {
   }, [code])
 
   return (
-    <div data-cy={ 'markmap' }>
-      <div className={ 'svg-container' } ref={ diagramContainer }/>
-      <div className={ 'text-right button-inside' }>
+    <div data-cy={'markmap'}>
+      <div className={'svg-container'} ref={diagramContainer} />
+      <div className={'text-right button-inside'}>
         <LockButton
-          locked={ disablePanAndZoom }
-          onLockedChanged={ (newState) => setDisablePanAndZoom(newState) }
-          title={ disablePanAndZoom ? t('renderer.markmap.locked') : t('renderer.markmap.unlocked') }
+          locked={disablePanAndZoom}
+          onLockedChanged={(newState) => setDisablePanAndZoom(newState)}
+          title={disablePanAndZoom ? t('renderer.markmap.locked') : t('renderer.markmap.unlocked')}
         />
       </div>
     </div>

--- a/src/redux/note-details/methods.ts
+++ b/src/redux/note-details/methods.ts
@@ -48,7 +48,7 @@ export const setNoteFrontmatter = (frontmatter: NoteFrontmatter | undefined): vo
   } as SetNoteFrontmatterFromRenderingAction)
 }
 
-export const SetCheckboxInMarkdownContent = (lineInMarkdown: number, checked: boolean): void => {
+export const setCheckboxInMarkdownContent = (lineInMarkdown: number, checked: boolean): void => {
   store.dispatch({
     type: NoteDetailsActionType.SET_CHECKBOX_IN_MARKDOWN_CONTENT,
     checked: checked,


### PR DESCRIPTION
### Component/Part
Split component

### Description
This PR fixes the split component. If you stop holding down your mouse button while the mouse is not on the document after starting the resizing mode, then the splitter isn't stuck in resizing mode anymore.
You can also move your mouse over the whole document to resize the split.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

