### PR TITLE
Remove pdf mimetype + Add upload mock response (3/3)

### DIFF
--- a/cypress/integration/fileUpload.spec.ts
+++ b/cypress/integration/fileUpload.spec.ts
@@ -33,7 +33,7 @@ describe('File upload', () => {
         method: 'GET',
         url: '/mock-backend/api/private/media/upload-post'
       }, {
-        statusCode: 201,
+        statusCode: 200,
         body: {
           link: imageUrl
         }

--- a/cypress/integration/fileUpload.spec.ts
+++ b/cypress/integration/fileUpload.spec.ts
@@ -31,7 +31,7 @@ describe('File upload', () => {
     beforeEach(() => {
       cy.intercept({
         method: 'POST',
-        url: '/mock-backend/api/private/media/upload'
+        url: '/mock-backend/api/private/media/upload-post'
       }, {
         statusCode: 201,
         body: {
@@ -86,7 +86,7 @@ describe('File upload', () => {
   it('upload fails', () => {
     cy.intercept({
       method: 'POST',
-      url: '/mock-backend/api/private/media/upload'
+      url: '/mock-backend/api/private/media/upload-post'
     }, {
       statusCode: 400
     })

--- a/cypress/integration/fileUpload.spec.ts
+++ b/cypress/integration/fileUpload.spec.ts
@@ -85,7 +85,7 @@ describe('File upload', () => {
 
   it('upload fails', () => {
     cy.intercept({
-      method: 'POST',
+      method: 'GET',
       url: '/mock-backend/api/private/media/upload-post'
     }, {
       statusCode: 400

--- a/cypress/integration/fileUpload.spec.ts
+++ b/cypress/integration/fileUpload.spec.ts
@@ -30,7 +30,7 @@ describe('File upload', () => {
   describe('upload works', () => {
     beforeEach(() => {
       cy.intercept({
-        method: 'POST',
+        method: 'GET',
         url: '/mock-backend/api/private/media/upload-post'
       }, {
         statusCode: 201,

--- a/public/mock-backend/api/private/media/upload-post
+++ b/public/mock-backend/api/private/media/upload-post
@@ -1,0 +1,3 @@
+{
+    "link": "/mock-backend/public/img/avatar.png"
+}

--- a/src/api/media/index.ts
+++ b/src/api/media/index.ts
@@ -5,6 +5,7 @@
  */
 
 import { ImageProxyResponse } from '../../components/markdown-renderer/replace-components/image/types'
+import { isMockMode } from '../../utils/test-modes'
 import { defaultFetchConfig, expectResponseCode, getApiUrl } from '../utils'
 
 export const getProxiedUrl = async (imageUrl: string): Promise<ImageProxyResponse> => {
@@ -23,16 +24,16 @@ export interface UploadedMedia {
   link: string
 }
 
-export const uploadFile = async (noteId: string, contentType: string, media: Blob): Promise<UploadedMedia> => {
-  const response = await fetch(getApiUrl() + 'media/upload', {
+export const uploadFile = async (noteId: string, media: Blob): Promise<UploadedMedia> => {
+  const response = await fetch(`${getApiUrl()}media/upload${isMockMode() ? '-post' : ''}`, {
     ...defaultFetchConfig,
     headers: {
-      'Content-Type': contentType,
+      'Content-Type': media.type,
       'HedgeDoc-Note': noteId
     },
-    method: 'POST',
-    body: media
+    method: isMockMode() ? 'GET' : 'POST',
+    body: isMockMode() ? undefined : media
   })
-  expectResponseCode(response, 201)
+  expectResponseCode(response, isMockMode() ? 200 : 201)
   return (await response.json()) as Promise<UploadedMedia>
 }

--- a/src/components/common/upload-image-mimetypes.ts
+++ b/src/components/common/upload-image-mimetypes.ts
@@ -5,7 +5,6 @@
  */
 
 export const supportedMimeTypes: string[] = [
-  'application/pdf',
   'image/apng',
   'image/bmp',
   'image/gif',
@@ -19,5 +18,3 @@ export const supportedMimeTypes: string[] = [
   'image/tiff',
   'image/webp'
 ]
-
-export const supportedMimeTypesJoined = supportedMimeTypes.join(', ')

--- a/src/components/editor-page/editor-pane/tool-bar/upload-image-button.tsx
+++ b/src/components/editor-page/editor-pane/tool-bar/upload-image-button.tsx
@@ -11,11 +11,13 @@ import { useTranslation } from 'react-i18next'
 import { ForkAwesomeIcon } from '../../../common/fork-awesome/fork-awesome-icon'
 import { UploadInput } from '../../sidebar/upload-input'
 import { handleUpload } from '../upload-handler'
-import { supportedMimeTypesJoined } from './utils/upload-image-mimetypes'
+import { supportedMimeTypes } from '../../../common/upload-image-mimetypes'
 
 export interface UploadImageButtonProps {
   editor?: Editor
 }
+
+const acceptedMimeTypes = supportedMimeTypes.join(', ')
 
 export const UploadImageButton: React.FC<UploadImageButtonProps> = ({ editor }) => {
   const { t } = useTranslation()
@@ -43,7 +45,7 @@ export const UploadImageButton: React.FC<UploadImageButtonProps> = ({ editor }) 
       <Button variant='light' onClick={buttonClick} title={t('editor.editorToolbar.uploadImage')}>
         <ForkAwesomeIcon icon={'upload'} />
       </Button>
-      <UploadInput onLoad={onUploadImage} acceptedFiles={supportedMimeTypesJoined} onClickRef={clickRef} />
+      <UploadInput onLoad={onUploadImage} acceptedFiles={acceptedMimeTypes} onClickRef={clickRef} />
     </Fragment>
   )
 }

--- a/src/components/editor-page/editor-pane/upload-handler.ts
+++ b/src/components/editor-page/editor-pane/upload-handler.ts
@@ -21,28 +21,16 @@ export const handleUpload = (file: File, editor: Editor): void => {
   const cursor = editor.getCursor()
   const uploadPlaceholder = `![${i18n.t('editor.upload.uploadFile', { fileName: file.name })}]()`
   const noteId = store.getState().noteDetails.id
+  const insertCode = (replacement: string) => {
+    editor.replaceRange(replacement, cursor, { line: cursor.line, ch: cursor.ch + uploadPlaceholder.length }, '+input')
+  }
   editor.replaceRange(uploadPlaceholder, cursor, cursor, '+input')
   uploadFile(noteId, file)
     .then(({ link }) => {
-      editor.replaceRange(
-        `![](${link})`,
-        cursor,
-        {
-          line: cursor.line,
-          ch: cursor.ch + uploadPlaceholder.length
-        },
-        '+input'
-      )
+      insertCode(`![](${link})`)
     })
-    .catch(() => {
-      editor.replaceRange(
-        '',
-        cursor,
-        {
-          line: cursor.line,
-          ch: cursor.ch + uploadPlaceholder.length
-        },
-        '+input'
-      )
+    .catch((error) => {
+      console.error('error while uploading file', error)
+      insertCode('')
     })
 }

--- a/src/components/editor-page/editor-pane/upload-handler.ts
+++ b/src/components/editor-page/editor-pane/upload-handler.ts
@@ -8,7 +8,7 @@ import { Editor } from 'codemirror'
 import i18n from 'i18next'
 import { uploadFile } from '../../../api/media'
 import { store } from '../../../redux'
-import { supportedMimeTypes } from './tool-bar/utils/upload-image-mimetypes'
+import { supportedMimeTypes } from '../../common/upload-image-mimetypes'
 
 export const handleUpload = (file: File, editor: Editor): void => {
   if (!file) {
@@ -25,7 +25,7 @@ export const handleUpload = (file: File, editor: Editor): void => {
   uploadFile(noteId, file)
     .then(({ link }) => {
       editor.replaceRange(
-        getCorrectSyntaxForLink(mimeType, link),
+        `![](${link})`,
         cursor,
         {
           line: cursor.line,
@@ -45,13 +45,4 @@ export const handleUpload = (file: File, editor: Editor): void => {
         '+input'
       )
     })
-}
-
-const getCorrectSyntaxForLink = (mimeType: string, link: string): string => {
-  switch (mimeType) {
-    case 'application/pdf':
-      return `{%pdf ${link} %}`
-    default:
-      return `![](${link})`
-  }
 }

--- a/src/components/editor-page/editor-pane/upload-handler.ts
+++ b/src/components/editor-page/editor-pane/upload-handler.ts
@@ -14,8 +14,7 @@ export const handleUpload = (file: File, editor: Editor): void => {
   if (!file) {
     return
   }
-  const mimeType = file.type
-  if (!supportedMimeTypes.includes(mimeType)) {
+  if (!supportedMimeTypes.includes(file.type)) {
     // this mimetype is not supported
     return
   }
@@ -23,7 +22,7 @@ export const handleUpload = (file: File, editor: Editor): void => {
   const uploadPlaceholder = `![${i18n.t('editor.upload.uploadFile', { fileName: file.name })}]()`
   const noteId = store.getState().noteDetails.id
   editor.replaceRange(uploadPlaceholder, cursor, cursor, '+input')
-  uploadFile(noteId, mimeType, file)
+  uploadFile(noteId, file)
     .then(({ link }) => {
       editor.replaceRange(
         getCorrectSyntaxForLink(mimeType, link),


### PR DESCRIPTION
### Component/Part
Upload

### Description
This PR removes the pdf mime type and adds a upload mock response.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
