### PR TITLE
Add extra test suite for emojis

### DIFF
--- a/cypress/integration/autocompletion.spec.ts
+++ b/cypress/integration/autocompletion.spec.ts
@@ -93,8 +93,6 @@ describe('Autocompletion', () => {
           .should('not.exist')
         cy.get('.CodeMirror-activeline > .CodeMirror-line > span')
           .should('have.text', ':hedgehog:')
-        cy.getMarkdownBody()
-          .should('have.text', '🦔')
       })
       it('via doubleclick', () => {
         cy.codemirrorFill(':hedg')
@@ -105,8 +103,6 @@ describe('Autocompletion', () => {
           .should('not.exist')
         cy.get('.CodeMirror-activeline > .CodeMirror-line > span')
           .should('have.text', ':hedgehog:')
-        cy.getMarkdownBody()
-          .should('have.text', '🦔')
       })
     })
 
@@ -121,9 +117,6 @@ describe('Autocompletion', () => {
           .should('not.exist')
         cy.get('.CodeMirror-activeline > .CodeMirror-line > span')
           .should('have.text', ':fa-facebook:')
-        cy.getMarkdownBody()
-          .find('p > i.fa.fa-facebook')
-          .should('exist')
       })
       it('via doubleclick', () => {
         cy.codemirrorFill(':fa-face')
@@ -134,9 +127,6 @@ describe('Autocompletion', () => {
           .should('not.exist')
         cy.get('.CodeMirror-activeline > .CodeMirror-line > span')
           .should('have.text', ':fa-facebook:')
-        cy.getMarkdownBody()
-          .find('p > i.fa.fa-facebook')
-          .should('exist')
       })
     })
   })

--- a/cypress/integration/emoji.spec.ts
+++ b/cypress/integration/emoji.spec.ts
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+describe('emojis', () => {
+
+  const HEDGEHOG_UNICODE_CHARACTER = '🦔'
+
+  beforeEach(() => {
+    cy.visitTestEditor()
+  })
+
+  it('renders an emoji shortcode', () => {
+    cy.codemirrorFill(':hedgehog:')
+    cy.getMarkdownBody()
+      .should('have.text', HEDGEHOG_UNICODE_CHARACTER)
+  })
+
+  it('renders an emoji unicode character', () => {
+    cy.codemirrorFill(HEDGEHOG_UNICODE_CHARACTER)
+    cy.getMarkdownBody()
+      .should('have.text', HEDGEHOG_UNICODE_CHARACTER)
+  })
+
+  it('renders an fork awesome icon', () => {
+    cy.codemirrorFill(':fa-matrix-org:')
+    cy.getMarkdownBody()
+      .find('i.fa.fa-matrix-org')
+      .should('be.visible')
+  })
+})


### PR DESCRIPTION
Signed-off-by: Tilman Vatteroth <git@tilmanvatteroth.de>

### Component/Part
E2E tests

### Description
This PR adds an extra test suite for the emoji substitution.

### Steps

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
