### PR TITLE
Add renderer ready state to global application state

### DIFF
--- a/src/components/editor-page/document-bar/document-info/document-info-line-word-count.tsx
+++ b/src/components/editor-page/document-bar/document-info/document-info-line-word-count.tsx
@@ -10,6 +10,7 @@ import { ShowIf } from '../../../common/show-if/show-if'
 import { DocumentInfoLine } from './document-info-line'
 import { UnitalicBoldText } from './unitalic-bold-text'
 import { useIFrameEditorToRendererCommunicator } from '../../render-context/iframe-editor-to-renderer-communicator-context-provider'
+import { useApplicationState } from '../../../../hooks/common/use-application-state'
 
 /**
  * Creates a new info line for the document information dialog that holds the
@@ -19,16 +20,22 @@ export const DocumentInfoLineWordCount: React.FC = () => {
   useTranslation()
   const iframeEditorToRendererCommunicator = useIFrameEditorToRendererCommunicator()
   const [wordCount, setWordCount] = useState<number | null>(null)
+  const rendererReady = useApplicationState((state) => state.editorConfig.rendererReady)
 
   useEffect(() => {
-    iframeEditorToRendererCommunicator?.onWordCountCalculated((words) => {
+    iframeEditorToRendererCommunicator.onWordCountCalculated((words) => {
       setWordCount(words)
     })
-    iframeEditorToRendererCommunicator?.sendGetWordCount()
     return () => {
-      iframeEditorToRendererCommunicator?.onWordCountCalculated(undefined)
+      iframeEditorToRendererCommunicator.onWordCountCalculated(undefined)
     }
   }, [iframeEditorToRendererCommunicator, setWordCount])
+
+  useEffect(() => {
+    if (rendererReady) {
+      iframeEditorToRendererCommunicator.sendGetWordCount()
+    }
+  }, [iframeEditorToRendererCommunicator, rendererReady])
 
   return (
     <DocumentInfoLine icon={'align-left'} size={'2x'}>

--- a/src/components/editor-page/render-context/iframe-renderer-to-editor-communicator-context-provider.tsx
+++ b/src/components/editor-page/render-context/iframe-renderer-to-editor-communicator-context-provider.tsx
@@ -31,7 +31,7 @@ export const IframeRendererToEditorCommunicatorContextProvider: React.FC = ({ ch
   const editorOrigin = useSelector((state: ApplicationState) => state.config.iframeCommunication.editorOrigin)
   const currentIFrameCommunicator = useMemo<IframeRendererToEditorCommunicator>(() => {
     const newCommunicator = new IframeRendererToEditorCommunicator()
-    newCommunicator.setOtherSide(window.parent, editorOrigin)
+    newCommunicator.setMessageTarget(window.parent, editorOrigin)
     return newCommunicator
   }, [editorOrigin])
 

--- a/src/components/editor-page/renderer-pane/hooks/use-on-iframe-load.ts
+++ b/src/components/editor-page/renderer-pane/hooks/use-on-iframe-load.ts
@@ -19,12 +19,12 @@ export const useOnIframeLoad = (
   return useCallback(() => {
     const frame = frameReference.current
     if (!frame || !frame.contentWindow) {
-      iframeCommunicator.unsetOtherSide()
+      iframeCommunicator.unsetMessageTarget()
       return
     }
 
     if (sendToRenderPage.current) {
-      iframeCommunicator.setOtherSide(frame.contentWindow, rendererOrigin)
+      iframeCommunicator.setMessageTarget(frame.contentWindow, rendererOrigin)
       sendToRenderPage.current = false
       return
     } else {

--- a/src/components/intro-page/intro-page.tsx
+++ b/src/components/intro-page/intro-page.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React, { useState } from 'react'
+import React from 'react'
 import { Trans } from 'react-i18next'
 import { Branding } from '../common/branding/branding'
 import {
@@ -20,10 +20,11 @@ import { ShowIf } from '../common/show-if/show-if'
 import { RendererType } from '../render-page/rendering-message'
 import { WaitSpinner } from '../common/wait-spinner/wait-spinner'
 import { IframeEditorToRendererCommunicatorContextProvider } from '../editor-page/render-context/iframe-editor-to-renderer-communicator-context-provider'
+import { useApplicationState } from '../../hooks/common/use-application-state'
 
 export const IntroPage: React.FC = () => {
   const introPageContent = useIntroPageContent()
-  const [rendererReady, setRendererReady] = useState<boolean>(true)
+  const rendererReady = useApplicationState((state) => state.editorConfig.rendererReady)
 
   return (
     <IframeEditorToRendererCommunicatorContextProvider>
@@ -45,7 +46,6 @@ export const IntroPage: React.FC = () => {
           <RenderIframe
             frameClasses={'w-100 overflow-y-hidden'}
             markdownContent={introPageContent as string}
-            onRendererReadyChange={setRendererReady}
             rendererType={RendererType.INTRO}
             forcedDarkMode={true}
           />

--- a/src/components/render-page/iframe-communicator.ts
+++ b/src/components/render-page/iframe-communicator.ts
@@ -4,38 +4,74 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+/**
+ * Error that will be thrown if a message couldn't be sent.
+ */
+export class IframeCommunicatorSendingError extends Error {}
+
+/**
+ * Base class for communication between renderer and editor.
+ */
 export abstract class IframeCommunicator<SEND, RECEIVE> {
-  protected otherSide?: Window
-  protected otherOrigin?: string
+  private messageTarget?: Window
+  private targetOrigin?: string
+  private communicationEnabled: boolean
 
   constructor() {
     window.addEventListener('message', this.handleEvent.bind(this))
+    this.communicationEnabled = false
   }
 
   public unregisterEventListener(): void {
     window.removeEventListener('message', this.handleEvent.bind(this))
   }
 
-  public setOtherSide(otherSide: Window, otherOrigin: string): void {
-    this.otherSide = otherSide
-    this.otherOrigin = otherOrigin
+  /**
+   * Sets the target for message sending.
+   * Messages can be sent as soon as the communication is enabled.
+   *
+   * @see enableCommunication
+   * @param otherSide The target {@link Window} that should receive the messages.
+   * @param otherOrigin The origin from the URL of the target. If this isn't correct then the message sending will produce CORS errors.
+   */
+  public setMessageTarget(otherSide: Window, otherOrigin: string): void {
+    this.messageTarget = otherSide
+    this.targetOrigin = otherOrigin
+    this.communicationEnabled = false
   }
 
-  public unsetOtherSide(): void {
-    this.otherSide = undefined
-    this.otherOrigin = undefined
+  /**
+   * Unsets the message target. Should be used if the old target isn't available anymore.
+   */
+  public unsetMessageTarget(): void {
+    this.messageTarget = undefined
+    this.targetOrigin = undefined
+    this.communicationEnabled = false
   }
 
-  public getOtherSide(): Window | undefined {
-    return this.otherSide
+  /**
+   * Enables the message communication.
+   * Should be called as soon as the other sides is ready to receive messages.
+   */
+  protected enableCommunication(): void {
+    this.communicationEnabled = true
   }
 
+  /**
+   * Sends a message to the message target.
+   *
+   * @param message The message to send.
+   */
   protected sendMessageToOtherSide(message: SEND): void {
-    if (this.otherSide === undefined || this.otherOrigin === undefined) {
-      console.error("Can't send message because otherSide is null", message)
-      return
+    if (this.messageTarget === undefined || this.targetOrigin === undefined) {
+      throw new IframeCommunicatorSendingError(`Other side is not set.\nMessage was: ${JSON.stringify(message)}`)
     }
-    this.otherSide.postMessage(message, this.otherOrigin)
+    if (!this.communicationEnabled) {
+      throw new IframeCommunicatorSendingError(
+        `Communication isn't enabled. Maybe the other side is not ready?\nMessage was: ${JSON.stringify(message)}`
+      )
+    }
+    this.messageTarget.postMessage(message, this.targetOrigin)
   }
 
   protected abstract handleEvent(event: MessageEvent<RECEIVE>): void

--- a/src/components/render-page/iframe-editor-to-renderer-communicator.ts
+++ b/src/components/render-page/iframe-editor-to-renderer-communicator.ts
@@ -106,6 +106,7 @@ export class IframeEditorToRendererCommunicator extends IframeCommunicator<
     const renderMessage = event.data
     switch (renderMessage.type) {
       case RenderIframeMessageType.RENDERER_READY:
+        this.enableCommunication()
         this.onRendererReadyHandler?.()
         return false
       case RenderIframeMessageType.SET_SCROLL_SOURCE_TO_RENDERER:

--- a/src/components/render-page/iframe-markdown-renderer.tsx
+++ b/src/components/render-page/iframe-markdown-renderer.tsx
@@ -38,7 +38,7 @@ export const IframeMarkdownRenderer: React.FC = () => {
   useEffect(() => iframeCommunicator.onSetDarkMode(setDarkMode), [iframeCommunicator])
   useEffect(() => iframeCommunicator.onSetScrollState(setScrollState), [iframeCommunicator, scrollState])
   useEffect(
-    () => iframeCommunicator?.onGetWordCount(countWordsInRenderedDocument),
+    () => iframeCommunicator.onGetWordCount(countWordsInRenderedDocument),
     [iframeCommunicator, countWordsInRenderedDocument]
   )
 

--- a/src/components/render-page/iframe-renderer-to-editor-communicator.ts
+++ b/src/components/render-page/iframe-renderer-to-editor-communicator.ts
@@ -46,6 +46,7 @@ export class IframeRendererToEditorCommunicator extends IframeCommunicator<
   }
 
   public sendRendererReady(): void {
+    this.enableCommunication()
     this.sendMessageToOtherSide({
       type: RenderIframeMessageType.RENDERER_READY
     })

--- a/src/redux/editor/methods.ts
+++ b/src/redux/editor/methods.ts
@@ -14,7 +14,8 @@ import {
   SetEditorLigaturesAction,
   SetEditorPreferencesAction,
   SetEditorSmartPasteAction,
-  SetEditorSyncScrollAction
+  SetEditorSyncScrollAction,
+  SetRendererReadyAction
 } from './types'
 
 export const loadFromLocalStorage = (): EditorConfig | undefined => {
@@ -42,6 +43,19 @@ export const setEditorMode = (editorMode: EditorMode): void => {
   const action: SetEditorConfigAction = {
     type: EditorConfigActionType.SET_EDITOR_VIEW_MODE,
     mode: editorMode
+  }
+  store.dispatch(action)
+}
+
+/**
+ * Dispatches a global application state change for the "renderer ready" state.
+ *
+ * @param rendererReady The new renderer ready state.
+ */
+export const setRendererReady = (rendererReady: boolean): void => {
+  const action: SetRendererReadyAction = {
+    type: EditorConfigActionType.SET_RENDERER_READY,
+    rendererReady
   }
   store.dispatch(action)
 }

--- a/src/redux/editor/reducers.ts
+++ b/src/redux/editor/reducers.ts
@@ -15,7 +15,8 @@ import {
   SetEditorLigaturesAction,
   SetEditorPreferencesAction,
   SetEditorSmartPasteAction,
-  SetEditorSyncScrollAction
+  SetEditorSyncScrollAction,
+  SetRendererReadyAction
 } from './types'
 
 const initialState: EditorConfig = {
@@ -23,6 +24,7 @@ const initialState: EditorConfig = {
   ligatures: true,
   syncScroll: true,
   smartPaste: true,
+  rendererReady: false,
   preferences: {
     theme: 'one-dark',
     keyMap: 'sublime',
@@ -55,6 +57,11 @@ export const EditorConfigReducer: Reducer<EditorConfig, EditorConfigActions> = (
       }
       saveToLocalStorage(newState)
       return newState
+    case EditorConfigActionType.SET_RENDERER_READY:
+      return {
+        ...state,
+        rendererReady: (action as SetRendererReadyAction).rendererReady
+      }
     case EditorConfigActionType.SET_LIGATURES:
       newState = {
         ...state,

--- a/src/redux/editor/types.ts
+++ b/src/redux/editor/types.ts
@@ -13,7 +13,8 @@ export enum EditorConfigActionType {
   SET_SYNC_SCROLL = 'editor/syncScroll/set',
   MERGE_EDITOR_PREFERENCES = 'editor/preferences/merge',
   SET_LIGATURES = 'editor/preferences/setLigatures',
-  SET_SMART_PASTE = 'editor/preferences/setSmartPaste'
+  SET_SMART_PASTE = 'editor/preferences/setSmartPaste',
+  SET_RENDERER_READY = 'editor/rendererReady/set'
 }
 
 export interface EditorConfig {
@@ -21,11 +22,16 @@ export interface EditorConfig {
   syncScroll: boolean
   ligatures: boolean
   smartPaste: boolean
+  rendererReady: boolean
   preferences: EditorConfiguration
 }
 
 export interface EditorConfigActions extends Action<EditorConfigActionType> {
   type: EditorConfigActionType
+}
+
+export interface SetRendererReadyAction extends EditorConfigActions {
+  rendererReady: boolean
 }
 
 export interface SetEditorSyncScrollAction extends EditorConfigActions {


### PR DESCRIPTION
### Component/Part
Iframe communication

### Description
This PR adds a new state to the redux store. This state defines if the iframe renderer is ready and e.g. is used for the word count display.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
