### PR TITLE
Add new data property to iframe that indicates if the content is ready.

### DIFF
--- a/cypress/support/getMarkdownRenderer.ts
+++ b/cypress/support/getMarkdownRenderer.ts
@@ -14,7 +14,7 @@ declare namespace Cypress {
 
 Cypress.Commands.add('getMarkdownRenderer', () => {
   return cy
-    .get(`iframe[data-cy="documentIframe"]`)
+    .get(`iframe[data-cy="documentIframe"][data-content-ready="true"]`)
     .should('be.visible')
     .its('0.contentDocument')
     .should('exist')

--- a/src/components/editor-page/renderer-pane/render-iframe.tsx
+++ b/src/components/editor-page/renderer-pane/render-iframe.tsx
@@ -140,6 +140,7 @@ export const RenderIframe: React.FC<RenderIframeProps> = ({
         {...(isTestMode() ? {} : { sandbox: 'allow-downloads allow-same-origin allow-scripts allow-popups' })}
         ref={frameReference}
         className={`border-0 ${frameClasses ?? ''}`}
+        data-content-ready={rendererReady}
       />
     </Fragment>
   )


### PR DESCRIPTION
### Component/Part
Iframe rendering

### Description
Some tests fail because the iframe hasn't loaded the inner hedgedoc renderer yet
but cypress tries to travel through the dom and verify the render results.
This PR fixes the race condition by forcing cypress to wait until the renderer is ready.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
