### PR TITLE
Reuse cache for e2e

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: Cache node_modules
+      - name: Cache yarn cache
         uses: actions/cache@v2
         id: yarn-cache
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - name: Cache node_modules
+      - name: Cache yarn cache
         uses: actions/cache@v2
         id: yarn-cache
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,17 +20,20 @@ jobs:
 
       - name: Cache build
         uses: actions/cache@v2.1.6
+        id: build-cache
         with:
           path: build
-          key: build-${{ hashFiles('src/**') }}
+          key: build-${{ github.sha }}
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
+        if: steps.build-cache.outputs.cache-hit != 'true'
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: Cache yarn cache
         uses: actions/cache@v2
         id: yarn-cache
+        if: steps.build-cache.outputs.cache-hit != 'true'
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-16-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -38,14 +41,17 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Set up NodeJS
+        if: steps.build-cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v2
         with:
           node-version: 16
 
       - name: Install dependencies
+        if: steps.build-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --prefer-offline
 
       - name: Build test production build
+        if: steps.build-cache.outputs.cache-hit != 'true'
         run: yarn build:test
 
       - uses: actions/upload-artifact@master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - name: Cache node_modules
+      - name: Cache yarn cache
         uses: actions/cache@v2
         id: yarn-cache
         with:
@@ -50,7 +50,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - name: Cache node_modules
+      - name: Cache yarn cache
         uses: actions/cache@v2
         id: yarn-cache
         with:


### PR DESCRIPTION
### Component/Part
CI e2e tests

### Description
This PR changes the cache key for the build directory in e2e tests to use the commit hash. By doing this the CI don't have to rebuild the same commit if the job gets restarted. 

(It also renames some misnamed steps.)

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
