### PR TITLE
Replace custom gist implementation with github rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 - Change editor font to "Fira Code"
 - Note tags can be set as yaml-array in frontmatter.
 - If only one external login provider is configured, the sign-in button will directly link to it.
+- Links in Gist-Frames work only if explicitly opened in new tabs.
 
 ---
 

--- a/src/components/markdown-renderer/replace-components/gist/gist-frame.scss
+++ b/src/components/markdown-renderer/replace-components/gist/gist-frame.scss
@@ -9,3 +9,18 @@
     filter: blur(3px);
   }
 }
+
+.gist-resizer-row {
+  display: flex;
+  justify-content: center;
+
+  .gist-resizer {
+    display: flex;
+    width: 48px;
+    height: 5px;
+    background: white;
+    border-radius: 90px;
+    cursor: row-resize;
+    box-shadow: black 0 0 3px;
+  }
+}

--- a/src/components/markdown-renderer/replace-components/gist/use-resize-gist-frame.ts
+++ b/src/components/markdown-renderer/replace-components/gist/use-resize-gist-frame.ts
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const isLeftMouseButtonClicked = (mouseEvent: MouseEvent): boolean => {
+  return mouseEvent.buttons === 1
+}
+
+/**
+ * Extracts the absolute horizontal position of the mouse or touch point from the event.
+ * If no position could be found or
+ *
+ * @param moveEvent
+ */
+const extractPointerPosition = (moveEvent: MouseEvent | TouchEvent): number => {
+  if (isMouseEvent(moveEvent)) {
+    return moveEvent.pageY
+  } else {
+    return moveEvent.touches[0]?.pageY
+  }
+}
+
+/**
+ * Checks if the given {@link Event} is a {@link MouseEvent}
+ * @param event the event to check
+ * @return {@code true} if the given event is a {@link MouseEvent}
+ */
+const isMouseEvent = (event: Event): event is MouseEvent => {
+  return (event as MouseEvent).buttons !== undefined
+}
+
+export type PointerEvent = MouseEvent | TouchEvent
+export type PointerEventHandler = (event: PointerEvent) => void
+
+/**
+ * Provides logic for resizing a {@link GistFrame gist frame} by dragging an element.
+ *
+ * @param initialFrameHeight The initial size for the frame
+ * @return An array containing the current frame height and function to start the resizing
+ */
+export const useResizeGistFrame = (initialFrameHeight: number): [number, PointerEventHandler] => {
+  const [frameHeight, setFrameHeight] = useState(initialFrameHeight)
+  const lastYPosition = useRef<number | undefined>(undefined)
+
+  const onMove = useCallback((moveEvent: MouseEvent | TouchEvent) => {
+    if (lastYPosition.current === undefined) {
+      return
+    }
+    if (isMouseEvent(moveEvent) && !isLeftMouseButtonClicked(moveEvent)) {
+      lastYPosition.current = undefined
+      moveEvent.preventDefault()
+      return undefined
+    }
+
+    const currentPointerPosition = extractPointerPosition(moveEvent)
+    const deltaPointerPosition = currentPointerPosition - lastYPosition.current
+    lastYPosition.current = currentPointerPosition
+    setFrameHeight((oldFrameHeight) => Math.max(0, oldFrameHeight + deltaPointerPosition))
+    moveEvent.preventDefault()
+  }, [])
+
+  const onStartResizing: PointerEventHandler = useCallback((event) => {
+    lastYPosition.current = extractPointerPosition(event)
+  }, [])
+
+  const onStopResizing = useCallback(() => {
+    if (lastYPosition.current !== undefined) {
+      lastYPosition.current = undefined
+    }
+  }, [])
+
+  useEffect(() => {
+    const moveHandler = onMove
+    const stopResizeHandler = onStopResizing
+    window.addEventListener('touchmove', moveHandler)
+    window.addEventListener('mousemove', moveHandler)
+    window.addEventListener('touchcancel', stopResizeHandler)
+    window.addEventListener('touchend', stopResizeHandler)
+    window.addEventListener('mouseup', stopResizeHandler)
+
+    return () => {
+      window.removeEventListener('touchmove', moveHandler)
+      window.removeEventListener('mousemove', moveHandler)
+      window.removeEventListener('touchcancel', stopResizeHandler)
+      window.removeEventListener('touchend', stopResizeHandler)
+      window.removeEventListener('mouseup', stopResizeHandler)
+    }
+  }, [onMove, onStopResizing])
+
+  return [frameHeight, onStartResizing]
+}

--- a/src/components/markdown-renderer/replace-components/gist/use-resize-gist-frame.ts
+++ b/src/components/markdown-renderer/replace-components/gist/use-resize-gist-frame.ts
@@ -6,17 +6,23 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-const isLeftMouseButtonClicked = (mouseEvent: MouseEvent): boolean => {
+/**
+ * Determines if the left mouse button is pressed in the given event
+ *
+ * @param mouseEvent the mouse event that should be checked
+ * @return {@code true} if the left mouse button is pressed. {@code false} otherwise.
+ */
+const isLeftMouseButtonPressed = (mouseEvent: MouseEvent): boolean => {
   return mouseEvent.buttons === 1
 }
 
 /**
- * Extracts the absolute horizontal position of the mouse or touch point from the event.
- * If no position could be found or
+ * Extracts the absolute vertical position of the mouse or touch point from the event.
  *
- * @param moveEvent
+ * @param moveEvent the vertical position of the mouse pointer or the first touch pointer.
+ * @return the extracted vertical position.
  */
-const extractPointerPosition = (moveEvent: MouseEvent | TouchEvent): number => {
+const extractVerticalPointerPosition = (moveEvent: MouseEvent | TouchEvent): number => {
   if (isMouseEvent(moveEvent)) {
     return moveEvent.pageY
   } else {
@@ -50,13 +56,13 @@ export const useResizeGistFrame = (initialFrameHeight: number): [number, Pointer
     if (lastYPosition.current === undefined) {
       return
     }
-    if (isMouseEvent(moveEvent) && !isLeftMouseButtonClicked(moveEvent)) {
+    if (isMouseEvent(moveEvent) && !isLeftMouseButtonPressed(moveEvent)) {
       lastYPosition.current = undefined
       moveEvent.preventDefault()
       return undefined
     }
 
-    const currentPointerPosition = extractPointerPosition(moveEvent)
+    const currentPointerPosition = extractVerticalPointerPosition(moveEvent)
     const deltaPointerPosition = currentPointerPosition - lastYPosition.current
     lastYPosition.current = currentPointerPosition
     setFrameHeight((oldFrameHeight) => Math.max(0, oldFrameHeight + deltaPointerPosition))
@@ -64,7 +70,7 @@ export const useResizeGistFrame = (initialFrameHeight: number): [number, Pointer
   }, [])
 
   const onStartResizing: PointerEventHandler = useCallback((event) => {
-    lastYPosition.current = extractPointerPosition(event)
+    lastYPosition.current = extractVerticalPointerPosition(event)
   }, [])
 
   const onStopResizing = useCallback(() => {


### PR DESCRIPTION
### Component/Part
Gist replacer

### Description
This PR replaces our custom gist frame implementation with the github embedding url (like https://gist.github.com/ErikMichelson/1fcd4867c3740dc1c9e3e78eb6dc2070.pibb).

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
