### PR TITLE
Fix code highlighting grid

### DIFF
--- a/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.scss
+++ b/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.scss
@@ -11,7 +11,7 @@
     @import '../../../../../../node_modules/highlight.js/styles/tomorrow-night-blue';
   }
 
-  code.hljs {
+  pre code.hljs {
     overflow-x: auto;
     background-color: rgba(27, 31, 35, .05);
 


### PR DESCRIPTION
### Component/Part
Code Highlighting

### Description
This PR fixes the layout of the code lighting component.
![image](https://user-images.githubusercontent.com/6124140/129786423-44c62be6-6fe4-4fa7-bc85-8defd3d6d60e.png)

=>

![image](https://user-images.githubusercontent.com/6124140/129786470-da2f561e-07e2-4d06-ac54-c0927a3b7c44.png)



### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
