### PR TITLE
Optimize renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
   "extends": [
     "config:base",
     ":gitSignOff",
-    ":maintainLockFilesWeekly",
-    ":dependencyDashboard"
+    ":maintainLockFilesWeekly"
   ],
   "labels": [
     "type: maintenance"

--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,7 @@
     "config:base",
     ":gitSignOff",
     ":maintainLockFilesWeekly",
-    ":dependencyDashboard",
-    ":pinVersions"
+    ":dependencyDashboard"
   ],
   "labels": [
     "type: maintenance"


### PR DESCRIPTION
### Component/Part
Renovate

### Description
This PR changes the renovate config:
- change version range strategy from "always pin" to "autodetect pin" by removing the config extension as the auto detection is already covered by `config:base`. (see https://docs.renovatebot.com/configuration-options/#rangestrategy).
- Remove `dependencyDashboard` as it is already covered by `config:base`

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
