### PR TITLE
Remove package "eslint-plugin-flowtype"

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "emoji-picker-element": "1.8.0",
     "emoji-picker-element-data": "1.2.0",
     "eslint-config-react-app": "6.0.0",
-    "eslint-plugin-flowtype": "5.9.0",
     "eslint-plugin-import": "2.24.2",
     "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-node": "11.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6447,7 +6447,7 @@ eslint-plugin-es@^3.0.0:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
 
-eslint-plugin-flowtype@5.9.0, eslint-plugin-flowtype@^5.2.0:
+eslint-plugin-flowtype@^5.2.0:
   version "5.9.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.9.0.tgz#8d2d81d3d79bb53470ed62b97409b31684757e30"
   integrity sha512-aBUVPA5Wt0XyuV3Wg8flfVqYJR6yR2nRLuyPwoTjCg5VTk4G1X1zQpInr39tUGgRxqrA+d+B9GYK4+/d1i0Rfw==


### PR DESCRIPTION
### Component/Part
ESLint

### Description
This PR removes the package "eslint-plugin-flowtype" because we don't use [flowtype](https://flow.org/).

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
