### PR TITLE
Fix DoS in CSV parser

### DIFF
--- a/src/components/markdown-renderer/replace-components/csv/csv-parser.ts
+++ b/src/components/markdown-renderer/replace-components/csv/csv-parser.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * Parses a given text and parses it as comma separated values (CSV)
+ * Parses a given text as comma separated values (CSV).
  *
  * @param csvText The raw csv text
  * @param csvColumnDelimiter The delimiter for the columns
@@ -17,8 +17,7 @@ export const parseCsv = (csvText: string, csvColumnDelimiter: string): string[][
     return []
   }
   const splitRegex = new RegExp(`${escapeRegexCharacters(csvColumnDelimiter)}(?=(?:[^"]*"[^"]*")*[^"]*$)`)
-  return rows.filter((row) => row !== '')
-             .map((row) => row.split(splitRegex))
+  return rows.filter((row) => row !== '').map((row) => row.split(splitRegex))
 }
 
 /**
@@ -26,6 +25,6 @@ export const parseCsv = (csvText: string, csvColumnDelimiter: string): string[][
  * @param unsafe The unescaped string
  * @return The escaped string
  */
-function escapeRegexCharacters(unsafe: string) {
+const escapeRegexCharacters = (unsafe: string): string => {
   return unsafe.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }

--- a/src/components/markdown-renderer/replace-components/csv/csv-parser.ts
+++ b/src/components/markdown-renderer/replace-components/csv/csv-parser.ts
@@ -4,11 +4,28 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+/**
+ * Parses a given text and parses it as comma separated values (CSV)
+ *
+ * @param csvText The raw csv text
+ * @param csvColumnDelimiter The delimiter for the columns
+ * @return the values splitted by rows and columns
+ */
 export const parseCsv = (csvText: string, csvColumnDelimiter: string): string[][] => {
   const rows = csvText.split('\n')
   if (!rows || rows.length === 0) {
     return []
   }
-  const splitRegex = new RegExp(`${csvColumnDelimiter}(?=(?:[^"]*"[^"]*")*[^"]*$)`)
-  return rows.filter((row) => row !== '').map((row) => row.split(splitRegex))
+  const splitRegex = new RegExp(`${escapeRegexCharacters(csvColumnDelimiter)}(?=(?:[^"]*"[^"]*")*[^"]*$)`)
+  return rows.filter((row) => row !== '')
+             .map((row) => row.split(splitRegex))
+}
+
+/**
+ * Escapes regex characters in the given string so it can be used as literal string in another regex.
+ * @param unsafe The unescaped string
+ * @return The escaped string
+ */
+function escapeRegexCharacters(unsafe: string) {
+  return unsafe.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }


### PR DESCRIPTION
### Component/Part
CSV parser

### Description
This PR fixes a DoS attack in the CSV parser by escaping the delimiter to prevent that the delimiter can be interpreted as regex character.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
