### PR TITLE
Fix missing scrollbars for abcjs overflow

### DIFF
--- a/src/components/markdown-renderer/replace-components/abc/abc.scss
+++ b/src/components/markdown-renderer/replace-components/abc/abc.scss
@@ -4,8 +4,17 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+
 .abcjs-score {
   @import "../../../../style/variables.scss";
+
+  .markdown-body & {
+    overflow-x: auto !important;
+  }
+
+  & > svg {
+    max-width: unset !important;
+  }
 
   &, text {
     font-family: $font-family-base;


### PR DESCRIPTION
### Component/Part
ABC.js frame

### Description
When the render view is to small then the abc js score is cut off. This PR adds an overflow scrollbar.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
