### PR TITLE
Remove unneeded props interface

### DIFF
--- a/src/components/editor-page/editor-pane/editor-pane.tsx
+++ b/src/components/editor-page/editor-pane/editor-pane.tsx
@@ -22,11 +22,6 @@ import './codemirror-imports'
 import { setNoteContent } from '../../../redux/note-details/methods'
 import { useNoteMarkdownContent } from '../../../hooks/common/use-note-markdown-content'
 
-export interface EditorPaneProps {
-  onContentChange: (content: string) => void
-  content: string
-}
-
 const onChange = (editor: Editor) => {
   for (const hinter of allHinters) {
     const searchTerm = findWordAtCursor(editor)


### PR DESCRIPTION
### Component/Part
Editor pane

### Description
This PR removes an unneeded props interface that was used in editor-pane

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
