### PR TITLE
Remove deprecated code in basic markdown-it configurator

### DIFF
--- a/src/components/markdown-renderer/basic-markdown-renderer.tsx
+++ b/src/components/markdown-renderer/basic-markdown-renderer.tsx
@@ -17,7 +17,7 @@ import { useCalculateLineMarkerPosition } from './utils/calculate-line-marker-po
 import { useExtractFirstHeadline } from './hooks/use-extract-first-headline'
 import { TocAst } from 'markdown-it-toc-done-right'
 import { useOnRefChange } from './hooks/use-on-ref-change'
-import { BasicMarkdownItConfigurator } from './markdown-it-configurator/BasicMarkdownItConfigurator'
+import { BasicMarkdownItConfigurator } from './markdown-it-configurator/basic-markdown-it-configurator'
 import { ImageClickHandler } from './replace-components/image/image-replacer'
 import { useTrimmedContent } from './hooks/use-trimmed-content'
 
@@ -52,14 +52,12 @@ export const BasicMarkdownRenderer: React.FC<BasicMarkdownRendererProps & Additi
 }) => {
   const markdownBodyRef = useRef<HTMLDivElement>(null)
   const currentLineMarkers = useRef<LineMarkers[]>()
-  const hasNewYamlError = useRef(false)
   const tocAst = useRef<TocAst>()
   const [trimmedContent, contentExceedsLimit] = useTrimmedContent(content)
 
   const markdownIt = useMemo(
     () =>
       new BasicMarkdownItConfigurator({
-        onParseError: (errorState) => (hasNewYamlError.current = errorState),
         onToc: (toc) => (tocAst.current = toc),
         onLineMarkers:
           onLineMarkerPositionChanged === undefined

--- a/src/components/markdown-renderer/markdown-it-configurator/basic-markdown-it-configurator.ts
+++ b/src/components/markdown-renderer/markdown-it-configurator/basic-markdown-it-configurator.ts
@@ -37,7 +37,6 @@ import { quoteExtra } from '../markdown-it-plugins/quote-extra'
 import { documentTableOfContents } from '../markdown-it-plugins/document-table-of-contents'
 
 export interface ConfiguratorDetails {
-  onParseError: (error: boolean) => void
   onToc: (toc: TocAst) => void
   onLineMarkers?: (lineMarkers: LineMarkers[]) => void
   useAlternativeBreaks?: boolean


### PR DESCRIPTION
### Component/Part
Markdown it configurator

### Description
This PR removes some deprecated and dead code. It's not necessary anymore because markdown it doesn't parses the frontmatter anymore.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
