### PR TITLE
Fix code highlighting

### DIFF
--- a/cypress/integration/autocompletion.spec.ts
+++ b/cypress/integration/autocompletion.spec.ts
@@ -26,9 +26,7 @@ describe('Autocompletion', () => {
         .should('have.text', '```abnf')
       cy.get('.CodeMirror-code > div:nth-of-type(3) > .CodeMirror-line > span  span')
         .should('have.text', '```')
-      cy.getMarkdownBody()
-        .find('pre > code')
-        .should('exist')
+      cy.getMarkdownBody().find('.code-highlighter').should('exist')
     })
     it('via doubleclick', () => {
       cy.codemirrorFill('```')
@@ -41,9 +39,7 @@ describe('Autocompletion', () => {
         .should('have.text', '```abnf')
       cy.get('.CodeMirror-code > div:nth-of-type(3) > .CodeMirror-line > span  span')
         .should('have.text', '```')
-      cy.getMarkdownBody()
-        .find('pre > code')
-        .should('exist')
+      cy.getMarkdownBody().find('.code-highlighter').should('exist')
     })
   })
 

--- a/cypress/integration/highlightedCodeBlock.spec.ts
+++ b/cypress/integration/highlightedCodeBlock.spec.ts
@@ -5,9 +5,7 @@
  */
 
 const findHljsCodeBlock = () => {
-  return cy.getMarkdownBody()
-           .find('pre > code.hljs')
-           .should('be.visible')
+  return cy.getMarkdownBody().find('.code-highlighter > code.hljs').should('be.visible')
 }
 
 describe('Code', () => {

--- a/src/components/editor-page/app-bar/help-button/help-modal.tsx
+++ b/src/components/editor-page/app-bar/help-button/help-modal.tsx
@@ -41,7 +41,7 @@ export const HelpModal: React.FC<HelpModalProps> = ({ show, onHide }) => {
   const tabTitle = useMemo(() => t('editor.documentBar.help') + ' - ' + t(`editor.help.${tab}`), [t, tab])
 
   return (
-    <CommonModal icon={'question-circle'} show={show} onHide={onHide} title={tabTitle}>
+    <CommonModal size={'lg'} icon={'question-circle'} show={show} onHide={onHide} title={tabTitle}>
       <Modal.Body>
         <nav className='nav nav-tabs'>
           <Button

--- a/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.scss
+++ b/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.scss
@@ -8,7 +8,7 @@
   @import '../../../../../../node_modules/highlight.js/styles/github';
 
   body.dark & {
-    @import '../../../../../../node_modules/highlight.js/styles/tomorrow-night-blue';
+    @import '../../../../../../node_modules/highlight.js/styles/github-dark';
   }
 
   pre code.hljs {

--- a/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.scss
+++ b/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.scss
@@ -11,53 +11,55 @@
     @import '../../../../../../node_modules/highlight.js/styles/github-dark';
   }
 
-  pre code.hljs {
-    overflow-x: auto;
-    background-color: rgba(27, 31, 35, .05);
+  pre, & {
+    code.hljs {
+      overflow-x: auto;
+      background-color: rgba(27, 31, 35, .05);
 
-    body.dark & {
-      background-color: rgb(27, 31, 35);
-    }
-
-    body.dark &, & {
-      padding: 16px;
-      display: grid;
-      grid-template-columns: auto minmax(0, 1fr);
-
-      .codeline {
-        grid-column: 2;
-        white-space: pre;
+      body.dark & {
+        background-color: rgb(27, 31, 35);
       }
 
-      .linenumber {
-        grid-column: 1;
-        position: relative;
-        cursor: default;
-        z-index: 4;
-        padding: 0 8px 0 0;
-        min-width: 20px;
-        box-sizing: content-box;
-        color: #afafaf;
-        border-right: 3px solid #6ce26c;
-        flex-direction: column;
-        overflow: hidden;
-        user-select: none;
-        align-items: flex-end;
-        display: none;
-      }
+      body.dark &, & {
+        padding: 16px;
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr);
 
-      &.showGutter {
-        .linenumber {
-          display: flex;
+        .codeline {
+          grid-column: 2;
+          white-space: pre;
         }
-      }
 
-      &.showGutter .codeline {
-        margin: 0 0 0 16px;
-      }
+        .linenumber {
+          grid-column: 1;
+          position: relative;
+          cursor: default;
+          z-index: 4;
+          padding: 0 8px 0 0;
+          min-width: 20px;
+          box-sizing: content-box;
+          color: #afafaf;
+          border-right: 3px solid #6ce26c;
+          flex-direction: column;
+          overflow: hidden;
+          user-select: none;
+          align-items: flex-end;
+          display: none;
+        }
 
-      &.wrapLines .codeline {
-        white-space: pre-wrap;
+        &.showGutter {
+          .linenumber {
+            display: flex;
+          }
+        }
+
+        &.showGutter .codeline {
+          margin: 0 0 0 16px;
+        }
+
+        &.wrapLines .codeline {
+          white-space: pre-wrap;
+        }
       }
     }
   }

--- a/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.scss
+++ b/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.scss
@@ -4,62 +4,60 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-.markdown-body {
+.code-highlighter {
   @import '../../../../../../node_modules/highlight.js/styles/github';
 
   body.dark & {
     @import '../../../../../../node_modules/highlight.js/styles/github-dark';
   }
 
-  pre, & {
-    code.hljs {
-      overflow-x: auto;
-      background-color: rgba(27, 31, 35, .05);
+  code.hljs {
+    overflow-x: auto;
+    background-color: rgba(27, 31, 35, .05);
 
-      body.dark & {
-        background-color: rgb(27, 31, 35);
+    body.dark & {
+      background-color: rgb(27, 31, 35);
+    }
+
+    body.dark &, & {
+      padding: 16px;
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr);
+
+      .codeline {
+        grid-column: 2;
+        white-space: pre;
       }
 
-      body.dark &, & {
-        padding: 16px;
-        display: grid;
-        grid-template-columns: auto minmax(0, 1fr);
+      .linenumber {
+        grid-column: 1;
+        position: relative;
+        cursor: default;
+        z-index: 4;
+        padding: 0 8px 0 0;
+        min-width: 20px;
+        box-sizing: content-box;
+        color: #afafaf;
+        border-right: 3px solid #6ce26c;
+        flex-direction: column;
+        overflow: hidden;
+        user-select: none;
+        align-items: flex-end;
+        display: none;
+      }
 
-        .codeline {
-          grid-column: 2;
-          white-space: pre;
-        }
-
+      &.showGutter {
         .linenumber {
-          grid-column: 1;
-          position: relative;
-          cursor: default;
-          z-index: 4;
-          padding: 0 8px 0 0;
-          min-width: 20px;
-          box-sizing: content-box;
-          color: #afafaf;
-          border-right: 3px solid #6ce26c;
-          flex-direction: column;
-          overflow: hidden;
-          user-select: none;
-          align-items: flex-end;
-          display: none;
+          display: flex;
         }
+      }
 
-        &.showGutter {
-          .linenumber {
-            display: flex;
-          }
-        }
+      &.showGutter .codeline {
+        margin: 0 0 0 16px;
+      }
 
-        &.showGutter .codeline {
-          margin: 0 0 0 16px;
-        }
-
-        &.wrapLines .codeline {
-          white-space: pre-wrap;
-        }
+      &.wrapLines .codeline {
+        white-space: pre-wrap;
       }
     }
   }

--- a/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.tsx
+++ b/src/components/markdown-renderer/replace-components/highlighted-fence/highlighted-code/highlighted-code.tsx
@@ -61,14 +61,14 @@ export const HighlightedCode: React.FC<HighlightedCodeProps> = ({ code, language
   }, [code, language, startLineNumber])
 
   return (
-    <Fragment>
+    <div className={'code-highlighter'}>
       <code className={`hljs ${startLineNumber !== undefined ? 'showGutter' : ''} ${wrapLines ? 'wrapLines' : ''}`}>
         {dom}
       </code>
       <div className={'text-right button-inside'}>
         <CopyToClipboardButton content={code} data-cy='copy-code-button' />
       </div>
-    </Fragment>
+    </div>
   )
 }
 


### PR DESCRIPTION
### Component/Part
Code highlighting and help modal

### Description
This PR fixes some minor bugs I encountered while testing something else.
- The code highlighting in the cheatsheet renders correctly now
- The code highlighting uses a dark theme that actually overwrites the colors of the light theme
- The size of the help modal got increased.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
