### PR TITLE
Add LGTM badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 ![e2e](https://github.com/hedgedoc/react-client/workflows/e2e/badge.svg)
 ![lint](https://github.com/hedgedoc/react-client/workflows/lint/badge.svg)
 ![lint](https://github.com/hedgedoc/react-client/workflows/lint/badge.svg)
+[![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/hedgedoc/react-client.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/hedgedoc/react-client/context:javascript)
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/hedgedoc/react-client.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/hedgedoc/react-client/alerts/)
 
 This is the new, improved and better looking frontend for HedgeDoc 2.0.
 Our goal is to recreate the current frontend in react and to improve it.


### PR DESCRIPTION
### Component/Part
README

### Description
This PR adds the LGTM badges to README.md

### Steps

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
