### PR TITLE
Change renderer origin for CORS

### DIFF
--- a/public/mock-backend/api/private/config
+++ b/public/mock-backend/api/private/config
@@ -39,6 +39,6 @@
   },
   "iframeCommunication": {
     "editorOrigin": "http://localhost:3001/",
-    "rendererOrigin": "http://localhost:3001/"
+    "rendererOrigin": "http://127.0.0.1:3001/"
   }
 }


### PR DESCRIPTION
### Component/Part
CORS while accessing renderer

### Description
This PR enforces protection for the renderer by using CORS while using the dev server. It's useful to test the effect of CORS on the communication. 

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
<!-- e.g #123 -->
