### PR TITLE
Use renovate to update cypress image

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,6 +64,7 @@ jobs:
     needs: build-frontend
     runs-on: ubuntu-latest
     container:
+      # renovate: datasource=docker depName=cypress/browsers versioning=docker
       image: cypress/browsers:node16.5.0-chrome94-ff93
       options: --user 1001 --shm-size=2g
     strategy:

--- a/renovate.json
+++ b/renovate.json
@@ -83,5 +83,14 @@
   "prHourlyLimit": 0,
   "schedule": [
     "on Saturday"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["\\.yml$", "\\.yaml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s+\\S+:\\s+\"?(?<currentValue>[^\"]*?)\"?\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
   ]
 }


### PR DESCRIPTION
### Component/Part
GitHub Workflow + Renovate

### Description
This PR adds support for updating the cypress docker image with renovate.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
