### PR TITLE
Enable redux devtools extension

### DIFF
--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -25,6 +25,7 @@ import { HistoryEntry } from './history/types'
 import { HistoryReducer } from './history/reducers'
 import { RendererStatusReducer } from './renderer-status/reducers'
 import { RendererStatus } from './renderer-status/types'
+import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly'
 
 export interface ApplicationState {
   user: OptionalUserState
@@ -52,4 +53,4 @@ export const allReducers: Reducer<ApplicationState> = combineReducers<Applicatio
   rendererStatus: RendererStatusReducer
 })
 
-export const store = createStore(allReducers)
+export const store = createStore(allReducers, composeWithDevTools())


### PR DESCRIPTION
### Component/Part
redux

### Description
This PR enables the redux devtools extension integration. We had the npm package for this installed since the beginning but didn't enable it.

Looks like this in Chrome:
![image](https://user-images.githubusercontent.com/52606896/137600585-8ac0ec4d-b5ad-407d-84d9-0e3e2d661175.png)

- [Extension for Firefox](https://addons.mozilla.org/de/firefox/addon/reduxdevtools/)
- [Extension for Chrome](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=de)

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
none
