### PR TITLE
Update @types/node to 16.11.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "@types/markdown-it-container": "2.0.4",
     "@types/markdown-it-plantuml": "1.4.1",
     "@types/mermaid": "8.2.7",
-    "@types/node": "15.6.0",
+    "@types/node": "16.11.6",
     "@types/react": "17.0.31",
     "@types/react-bootstrap-typeahead": "5.1.8",
     "@types/react-dom": "17.0.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2438,10 +2438,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.4.tgz#90771124822d6663814f7c1c9b45a6654d8fd964"
   integrity sha512-TMgXmy0v2xWyuCSCJM6NCna2snndD8yvQF67J29ipdzMcsPa9u+o0tjF5+EQNdhcuZplYuouYqpc4zcd5I6amQ==
 
-"@types/node@15.6.0":
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.6.0.tgz#f0ddca5a61e52627c9dcb771a6039d44694597bc"
-  integrity sha512-gCYSfQpy+LYhOFTKAeE8BkyGqaxmlFxe+n4DKM6DR0wzw/HISUE/hAmkC/KT8Sw5PCJblqg062b3z9gucv3k0A==
+"@types/node@16.11.6":
+  version "16.11.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.6.tgz#6bef7a2a0ad684cf6e90fcfe31cecabd9ce0a3ae"
+  integrity sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==
 
 "@types/node@^14.14.31":
   version "14.17.29"


### PR DESCRIPTION
### Component/Part
package.json

### Description
This PR updates @types/node to 16.11.6 because https://github.com/hedgedoc/react-client/pull/1430 also wants to update @types/jest which is not possible right now.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
