### PR TITLE
Change scss import of reveal to css

### DIFF
--- a/src/components/markdown-renderer/slideshow.scss
+++ b/src/components/markdown-renderer/slideshow.scss
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-@import "../../../node_modules/reveal.js/css/reveal";
+@import "../../../node_modules/reveal.js/dist/reveal.css";
 @import "../../../node_modules/reveal.js/dist/theme/fonts/league-gothic/league-gothic.css";
 @import "slide-theme";


### PR DESCRIPTION
### Component/Part
RevealJs

### Description
This PR changes the scss import of reveal.js to the css file to get rid of the sass deprecation warning.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
