### PR TITLE
fix dead link to FAQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 - The `[name=...]`, `[time=...]` and `[color=...]` tags may now be used anywhere in the document and not just inside of blockquotes and lists.
 - The <i class="fa fa-picture-o"/> (add image) and <i class="fa fa-link"/> (add link) toolbar buttons put selected links directly in the `()` instead of the `[]` part of the generated markdown.
 - The help dialog has multiple tabs, and is a bit more organized.
-- Use KaTeX instead of MathJax. ([Why?](https://hedgedoc.org/faq/))
+- Use KaTeX instead of MathJax. ([Why?](https://docs.hedgedoc.org/faq/))
 - The dark-mode is also applied to the read-only-view and can be toggled from there.
 - Access tokens for the CLI and 3rd-party-clients can be managed in the user profile.
 - Change editor font to "Fira Code"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 - The `[name=...]`, `[time=...]` and `[color=...]` tags may now be used anywhere in the document and not just inside of blockquotes and lists.
 - The <i class="fa fa-picture-o"/> (add image) and <i class="fa fa-link"/> (add link) toolbar buttons put selected links directly in the `()` instead of the `[]` part of the generated markdown.
 - The help dialog has multiple tabs, and is a bit more organized.
-- Use KaTeX instead of MathJax. ([Why?](https://docs.hedgedoc.org/faq/))
+- Use KaTeX instead of MathJax. ([Why?](https://github.com/hedgedoc/react-client/issues/495))
 - The dark-mode is also applied to the read-only-view and can be toggled from there.
 - Access tokens for the CLI and 3rd-party-clients can be managed in the user profile.
 - Change editor font to "Fira Code"


### PR DESCRIPTION
Signed-off-by: Stéphane Guillou <stephane.guillou@member.fsf.org>

Note that the FAQ doesn't give a MathJax vs KaTeX explanation just yet.
Some reasons for the switch are here: https://github.com/hedgedoc/react-client/issues/495

### Component/Part

Client changelog

### Description

Correct a dead link.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)

None

