### PR TITLE
Remove useMemo from interval

### DIFF
--- a/src/components/notifications/ui-notification-toast.tsx
+++ b/src/components/notifications/ui-notification-toast.tsx
@@ -49,7 +49,7 @@ export const UiNotificationToast: React.FC<UiNotificationProps> = ({
 
   useInterval(
     () => setRemainingSteps((lastRemainingSteps) => lastRemainingSteps - 1),
-    useMemo(() => (dismissed || remainingSteps <= 0 ? null : 1000 / STEPS_PER_SECOND), [dismissed, remainingSteps])
+    !dismissed && remainingSteps > 0 ? 1000 / STEPS_PER_SECOND : null
   )
 
   useEffect(() => {


### PR DESCRIPTION
### Component/Part
Notification

### Description
This PR removes the `useMemo` from the interval in the ui-notification component because the value is not complex.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
