### PR TITLE
fix: use text direction auto

### DIFF
--- a/src/components/history-page/history-toolbar/history-view-mode-toggle-button.tsx
+++ b/src/components/history-page/history-toolbar/history-view-mode-toggle-button.tsx
@@ -33,7 +33,7 @@ export const HistoryViewModeToggleButton: React.FC = () => {
     <ToggleButtonGroup
       type='radio'
       name='options'
-      dir='ltr'
+      dir='auto'
       value={historyToolbarState.viewState}
       className={'button-height'}
       onChange={onViewStateChange}>


### PR DESCRIPTION
### Component/Part
HistoryViewModeToggleButton 

### Description
This PR fixes the text direction

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
fixes #1725