### PR TITLE
Add etag header to last modified check of motd

### DIFF
--- a/cypress/integration/motd.spec.ts
+++ b/cypress/integration/motd.spec.ts
@@ -9,16 +9,16 @@ const MOCK_LAST_MODIFIED = 'mockETag'
 const motdMockContent = 'This is the mock Motd call'
 
 describe('Motd', () => {
-  const mockExistingMotd = () => {
+  const mockExistingMotd = (useEtag?: boolean) => {
     cy.intercept('GET', '/mock-backend/public/motd.txt', {
       statusCode: 200,
-      headers: { 'Last-Modified': MOCK_LAST_MODIFIED },
+      headers: { [useEtag ? 'etag' : 'Last-Modified']: MOCK_LAST_MODIFIED },
       body: motdMockContent
     })
 
     cy.intercept('HEAD', '/mock-backend/public/motd.txt', {
       statusCode: 200,
-      headers: { 'Last-Modified': MOCK_LAST_MODIFIED }
+      headers: { [useEtag ? 'etag' : 'Last-Modified']: MOCK_LAST_MODIFIED }
     })
   }
 
@@ -30,6 +30,18 @@ describe('Motd', () => {
     mockExistingMotd()
     cy.visit('/')
     cy.getByCypressId('motd').contains(motdMockContent)
+  })
+
+  it('can be dismissed using etag', () => {
+    mockExistingMotd(true)
+    cy.visit('/')
+    cy.getByCypressId('motd').contains(motdMockContent)
+    cy.getByCypressId('motd-dismiss')
+      .click()
+      .then(() => {
+        expect(localStorage.getItem(MOTD_LOCAL_STORAGE_KEY)).to.equal(MOCK_LAST_MODIFIED)
+      })
+    cy.getByCypressId('motd').should('not.exist')
   })
 
   it('can be dismissed', () => {

--- a/src/components/application-loader/initializers/fetch-motd.ts
+++ b/src/components/application-loader/initializers/fetch-motd.ts
@@ -50,7 +50,7 @@ export const fetchMotd = async (customizeAssetsUrl: string): Promise<void> => {
 
   const lastModified = response.headers.get('Last-Modified') || response.headers.get('etag')
   if (!lastModified) {
-    log.warn("'Last-Modified' not found for motd.txt!")
+    log.warn("'Last-Modified' or 'Etag' not found for motd.txt!")
   }
 
   setMotd(motdText, lastModified)

--- a/src/components/application-loader/initializers/fetch-motd.ts
+++ b/src/components/application-loader/initializers/fetch-motd.ts
@@ -32,7 +32,8 @@ export const fetchMotd = async (customizeAssetsUrl: string): Promise<void> => {
     if (response.status !== 200) {
       return
     }
-    if (response.headers.get('Last-Modified') === cachedLastModified) {
+    const lastModified = response.headers.get('Last-Modified') || response.headers.get('etag')
+    if (lastModified === cachedLastModified) {
       return
     }
   }
@@ -47,7 +48,7 @@ export const fetchMotd = async (customizeAssetsUrl: string): Promise<void> => {
 
   const motdText = await response.text()
 
-  const lastModified = response.headers.get('Last-Modified')
+  const lastModified = response.headers.get('Last-Modified') || response.headers.get('etag')
   if (!lastModified) {
     log.warn("'Last-Modified' not found for motd.txt!")
   }


### PR DESCRIPTION
### Component/Part
Motd

### Description
Some hosters (like vercel.app) don't provide a "last modified" header, but an etag. 
This PR includes the etag into the motd "last modified" check.

### Steps
- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
