### PR TITLE
Don't upload cache to build artifact

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,7 +57,9 @@ jobs:
       - uses: actions/upload-artifact@master
         with:
           name: next-build
-          path: .next
+          path: |
+            .next
+            !.next/cache
 
   end2end:
     name: Perform E2E Test in ${{ matrix.browser }}


### PR DESCRIPTION
### Component/Part
CI

### Description
This PR excludes the next cache from the artifact upload. This reduces the artifact since from 200 to 20 MB.

### Steps
- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
