### PR TITLE
Use yarn berry install command in cypress action

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -93,6 +93,7 @@ jobs:
           group: "UI - ${{ matrix.browser }}"
           wait-on: 'http://127.0.0.1:3001/'
           wait-on-timeout: 120
+          install-command: yarn install --immutable --silent
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Component/Part
CI

### Description
The default install command of the cypress action uses "--frozen-lockfile" which is not available in yarn berry. This PR adds a custom install command for yarn berry.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
