### PR TITLE
Reduce number of e2e containers to 5

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         browser: [ 'chrome', 'firefox' ]
-        containers: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
+        containers: [ 1, 2, 3, 4, 5 ]
     steps:
       - name: Check out repo
         uses: actions/checkout@v2


### PR DESCRIPTION
### Component/Part
E2E tests

### Description
This PR reduces the number of containers for the e2e test to 5 so chrome and firefox can run at the same time.

### Steps

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
