### PR TITLE
Add condition to modal

### DIFF
--- a/src/components/common/modals/common-modal.tsx
+++ b/src/components/common/modals/common-modal.tsx
@@ -48,23 +48,25 @@ export const CommonModal: React.FC<CommonModalProps> = ({
   }, [title, titleIsI18nKey])
 
   return (
-    <Modal
-      {...cypressId(props)}
-      show={show}
-      onHide={onHide}
-      animation={true}
-      dialogClassName={`text-dark ${additionalClasses ?? ''}`}
-      size={modalSize}>
-      <Modal.Header closeButton={!!showCloseButton}>
-        <Modal.Title>
-          <ShowIf condition={!!titleIcon}>
-            <ForkAwesomeIcon icon={titleIcon as IconName} />
-            &nbsp;
-          </ShowIf>
-          {titleElement}
-        </Modal.Title>
-      </Modal.Header>
-      {children}
-    </Modal>
+    <ShowIf condition={show}>
+      <Modal
+        {...cypressId(props)}
+        show={show}
+        onHide={onHide}
+        animation={true}
+        dialogClassName={`text-dark ${additionalClasses ?? ''}`}
+        size={modalSize}>
+        <Modal.Header closeButton={!!showCloseButton}>
+          <Modal.Title>
+            <ShowIf condition={!!titleIcon}>
+              <ForkAwesomeIcon icon={titleIcon as IconName} />
+              &nbsp;
+            </ShowIf>
+            {titleElement}
+          </Modal.Title>
+        </Modal.Header>
+        {children}
+      </Modal>
+    </ShowIf>
   )
 }


### PR DESCRIPTION
### Component/Part
Modals

### Description
This PR adds a condition to the DOM generation of modals.
This way we prevent unwanted data loading, invisible updates
and visual artifacts when the modal isn't visible.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
