### PR TITLE
Netlify

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+<!--
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+Contributor Code of Conduct
+===
+
+As contributors and maintainers of this project, and in the interest of fostering an open and
+welcoming community, we pledge to respect all people who contribute through reporting issues,
+posting feature requests, updating documentation, submitting pull requests or patches, and other
+activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone,
+regardless of level of experience, gender, gender identity and expression, sexual orientation,
+disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit
+  permission
+* Other unethical or unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits,
+code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By
+adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently
+applying these principles to every aspect of managing this project. Project maintainers who do not
+follow or enforce the Code of Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is
+representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an
+issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org),
+version 1.2.0, available at
+[http://contributor-covenant.org/version/1/2/0/](http://contributor-covenant.org/version/1/2/0/)

--- a/README.md
+++ b/README.md
@@ -72,3 +72,9 @@ This will build the app in production mode and save it into the `.next` folder. 
 best performance, minimized and the filenames include a hash value of the content. Don't edit them by hand!
 
 You can run the production build using the built-in server with `yarn start`.
+
+## UI Test
+
+Curious about the new look and feel? We provide a demo of the new UI on [hedgedoc.dev](https://hedgedoc.dev). This version uses mocked data and has no data persistence.
+
+The UI test is hosted by [netlify](https://netlify.com). Please check their [privacy policy](https://netlify.com/privacy) as well as [ours](https://hedgedoc.org/privacy-policy).

--- a/netlify/intro.md
+++ b/netlify/intro.md
@@ -1,0 +1,13 @@
+<!--
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+:::warning
+What you see is an UI-Test! It's filled with dummy data, not connected to a backend and no data will be saved.
+:::
+
+![HedgeDoc Screenshot](/mock-backend/public/screenshot.png)
+
+[![Deployed using netlify](https://www.netlify.com/img/global/badges/netlify-color-accent.svg)](https://www.netlify.com)

--- a/netlify/motd.txt
+++ b/netlify/motd.txt
@@ -1,0 +1,2 @@
+This demo is hosted by netlify.
+Please check their privacy policy (https://netlify.com/privacy) as well as ours (https://hedgedoc.org/privacy-policy).

--- a/netlify/motd.txt.license
+++ b/netlify/motd.txt.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+
+SPDX-License-Identifier: CC0-1.0

--- a/netlify/patch-intro.js
+++ b/netlify/patch-intro.js
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+const { copyFile } = require('fs/promises');
+
+console.log("Patch intro.md to include netlify banner.")
+copyFile("netlify/intro.md", "public/mock-backend/public/intro.md")
+  .then(() => console.log("Copied intro.md"))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })
+
+console.log("Patch motd.txt to include privacy policy.")
+copyFile("netlify/motd.txt", "public/mock-backend/public/motd.txt")
+  .then(() => console.log("Copied motd.txt"))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "AGPL-3.0",
   "scripts": {
     "build": "next build",
+    "build:netlify": "node netlify/patch-intro.js && cross-env NEXT_PUBLIC_IGNORE_IFRAME_ORIGIN_CONFIG=true yarn build:mock",
     "build:mock": "cross-env NEXT_PUBLIC_USE_MOCK_API=true next build",
     "build:test": "cross-env NEXT_PUBLIC_USE_MOCK_API=true NEXT_PUBLIC_TEST_MODE=true next build",
     "analyze": "cross-env ANALYZE=true next build",


### PR DESCRIPTION
### Component/Part
README and deployment

### Description
This PR
- adds the netlify badge to the intro.md if it get's deployed using netlify.
- adds a copy of our code of conduct from the main repository which is necessary for the netlify open source sponsoring.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

