### PR TITLE
Add plantuml not configured tag to tag name whiteliste

### DIFF
--- a/src/components/markdown-renderer/markdown-extension/plantuml/plantuml-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/plantuml/plantuml-markdown-extension.ts
@@ -40,6 +40,10 @@ export class PlantumlMarkdownExtension extends MarkdownExtension {
     }
   }
 
+  public buildTagNameWhitelist(): string[] {
+    return ['plantuml-not-configured']
+  }
+
   buildReplacers(): ComponentReplacer[] {
     return [new PlantumlNotConfiguredComponentReplacer()]
   }


### PR DESCRIPTION
### Component/Part
PlantUML Extension

### Description
This PR adds the plantuml-not-configured tag to the dom purify whitelist.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
