### PR TITLE
deployments: Fix main branch deployment and overrides

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run netlify CLI deployment
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        run: bash netlify/deploy.sh "${{ github.event.number }}" "${{ github.head_ref }}"
+        run: bash netlify/deploy.sh "${{ github.event.number }}" "${{ github.head_ref }}" "${{ github.event.pull_request.title }}"
         id: netlify-result
 
       - name: Mark GitHub deployment as finished

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           step: start
           token: ${{ secrets.GITHUB_TOKEN }}
-          env: Preview
+          env: "PR #${{ github.event.number }}"
           no_override: false
           ref: ${{ github.head_ref }}
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 publish = ".next"
-command = "echo 'Assuming already built and cleaned Next.js app at ./.next/'"
+command = "bash netlify/build.sh"
 
 [[plugins]]
 package = "@netlify/plugin-nextjs"

--- a/netlify/build.sh
+++ b/netlify/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+if [[ -z "${GITHUB_ACTIONS}" ]]; then
+    echo "Running in netlify CI or manual"
+    yarn build:netlify
+else
+    echo "Running in GitHub actions CI"
+    echo "Build is not necessary as already done prior to this step."
+fi

--- a/netlify/build.sh
+++ b/netlify/build.sh
@@ -6,7 +6,7 @@
 
 if [[ -z "${GITHUB_ACTIONS}" ]]; then
     echo "Running in netlify CI or manual"
-    yarn build:netlify
+    exec yarn build:netlify
 else
     echo "Running in GitHub actions CI"
     echo "Build is not necessary as already done prior to this step."

--- a/netlify/deploy.sh
+++ b/netlify/deploy.sh
@@ -6,7 +6,7 @@
 
 deployid="$1-$2"
 
-json=$(yarn netlify deploy --build --context deploy-preview --alias "${deployid}" --json)
+json=$(yarn netlify deploy --build --context deploy-preview --alias "${deployid}" --json --message "[#$1] $3")
 
 url=$(echo "${json}" | jq -r .deploy_url)
 logs=$(echo "${json}" | jq -r .logs)


### PR DESCRIPTION
### Component/Part
PR deployments

### Description
This PR fixes/enhances three things of the deployments:

#### **GitHub deploy links**
GitHub deployment links were overriden by different PRs because we used the same environment across every PR. This PR adds a new environment per PR in the workflow.

![image](https://user-images.githubusercontent.com/52606896/151362192-99740f1d-88ff-4c26-afd3-b5781e4466d6.png)

#### **Fixing main branch deployment**
The main deployment broke due to the yarn build command not executed. This PR adds a build script which executes the command when not being in GitHub actions.

#### **Adding deployment information to netlify UI**
The app.netlify.com Interface had no information about the deployed branch and only labeled the deployments as "Branch deployment". This PR adds a message containing the PR number and title to each deployment.

![image](https://user-images.githubusercontent.com/52606896/151362382-7e4d6865-5a4e-478a-85b0-664f696da012.png)


### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
none
