### PR TITLE
Fix netlify not using aliases containing a slash

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run netlify CLI deployment
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        run: bash netlify/deploy.sh "${{ github.event.number }}" "${{ github.head_ref }}" "${{ github.event.pull_request.title }}"
+        run: bash netlify/deploy.sh "${{ github.event.number }}" "${{ github.event.pull_request.title }}"
         id: netlify-result
 
       - name: Mark GitHub deployment as finished

--- a/netlify/deploy.sh
+++ b/netlify/deploy.sh
@@ -4,9 +4,9 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-deployid="$1-$2"
+json=$(yarn netlify deploy --build --context deploy-preview --alias "$1" --json --message "[#$1] $2")
 
-json=$(yarn netlify deploy --build --context deploy-preview --alias "${deployid}" --json --message "[#$1] $3")
+echo "${json}"
 
 url=$(echo "${json}" | jq -r .deploy_url)
 logs=$(echo "${json}" | jq -r .logs)


### PR DESCRIPTION
### Component/Part
netlify deployments

### Description
This PR removes the branch name from the deployment alias since slashes (and other special characters) are known to break the deployment URLs, which then result in an error 404.

See https://github.com/netlify/cli/issues/969

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
none
