### PR TITLE
Update cypress/browser to node16.13.2-chrome97-ff96

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # renovate: datasource=docker depName=cypress/browsers versioning=docker
-      image: cypress/browsers:node16.5.0-chrome94-ff93
+      image: cypress/browsers:node16.13.2-chrome97-ff96
       options: --user 1001 --shm-size=2g
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Component/Part
GitHub Actions

### Description
This PR updates the image that is used in the e2e workflow.

### Steps

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
