### PR TITLE
Fix renovate match string for docker images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -86,9 +86,12 @@
   ],
   "regexManagers": [
     {
-      "fileMatch": ["\\.yml$", "\\.yaml$"],
+      "fileMatch": [
+        "\\.yml$",
+        "\\.yaml$"
+      ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s+\\S+:\\s+\"?(?<currentValue>[^\"]*?)\"?\\s"
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s+\\S+:\\s+\"?[^:]+:(?<currentValue>[^\"]*?)\"?\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }


### PR DESCRIPTION
### Component/Part
Renovate

### Description
This PR fixes the renovate match string to detect docker image tags correctly.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
Fixes #1855
