### PR TITLE
Post toc after rendering and not during it

### DIFF
--- a/src/components/markdown-renderer/hooks/use-markdown-extensions.ts
+++ b/src/components/markdown-renderer/hooks/use-markdown-extensions.ts
@@ -5,7 +5,7 @@
  */
 
 import type { MutableRefObject } from 'react'
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 import { TableOfContentsMarkdownExtension } from '../markdown-extension/table-of-contents-markdown-extension'
 import { VegaLiteMarkdownExtension } from '../markdown-extension/vega-lite/vega-lite-markdown-extension'
 //TODO: fix dependency issues in markmap
@@ -42,6 +42,7 @@ import type { MarkdownExtension } from '../markdown-extension/markdown-extension
 import { IframeCapsuleMarkdownExtension } from '../markdown-extension/iframe-capsule/iframe-capsule-markdown-extension'
 import { ImagePlaceholderMarkdownExtension } from '../markdown-extension/image-placeholder/image-placeholder-markdown-extension'
 import { UploadIndicatingImageFrameMarkdownExtension } from '../markdown-extension/upload-indicating-image-frame/upload-indicating-image-frame-markdown-extension'
+import { useOnRefChange } from './use-on-ref-change'
 
 /**
  * Provides a list of {@link MarkdownExtension markdown extensions} that is a combination of the common extensions and the given additional.
@@ -65,10 +66,12 @@ export const useMarkdownExtensions = (
   onTocChange?: (ast?: TocAst) => void
 ): MarkdownExtension[] => {
   const plantumlServer = useApplicationState((state) => state.config.plantumlServer)
+  const toc = useRef<TocAst | undefined>(undefined)
+  useOnRefChange(toc, onTocChange)
 
   return useMemo(() => {
     return [
-      new TableOfContentsMarkdownExtension(onTocChange),
+      new TableOfContentsMarkdownExtension((ast?: TocAst) => (toc.current = ast)),
       ...additionalExtensions,
       new VegaLiteMarkdownExtension(),
       // new MarkmapMarkdownExtension(),
@@ -103,14 +106,5 @@ export const useMarkdownExtensions = (
       new HighlightedCodeMarkdownExtension(),
       new DebuggerMarkdownExtension()
     ]
-  }, [
-    additionalExtensions,
-    baseUrl,
-    currentLineMarkers,
-    lineOffset,
-    onImageClick,
-    onTaskCheckedChange,
-    onTocChange,
-    plantumlServer
-  ])
+  }, [additionalExtensions, baseUrl, currentLineMarkers, lineOffset, onImageClick, onTaskCheckedChange, plantumlServer])
 }


### PR DESCRIPTION
### Component/Part
Markdown Rendering

### Description
This PR fixes a bug in the rendering pipeline.
During the markdown-to-react conversion (which happens in the rendering, NOT in an effect) the toc is posted via callback from the markdown it instance. 
This callback sets the toc in the state of a higher component. This triggers the re-rendering of the sidebar. 
This causes an error because a state update in another component is done during the rendering of the markdown document.

![image](https://user-images.githubusercontent.com/6124140/161396975-4cbe8cc2-b2cb-47d3-bc60-fc79ffbaa05b.png)


This PR moves the execution of the callback into an effect that is triggered AFTER the rendering.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
