### PR TITLE
Change year in copyright from 2021 to 2022

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.env.development.license
+++ b/.env.development.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/.env.production.license
+++ b/.env.production.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/.env.test.license
+++ b/.env.test.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/.eslintrc.json.license
+++ b/.eslintrc.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.mailmap.license
+++ b/.mailmap.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/.nvmrc.license
+++ b/.nvmrc.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/.prettierignore.license
+++ b/.prettierignore.license
@@ -1,4 +1,4 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0
 

--- a/.prettierrc.json.license
+++ b/.prettierrc.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,19 +4,19 @@ Upstream-Contact: The HedgeDoc developers <license@hedgedoc.org>
 Source: https://github.com/hedgedoc/react-client
 
 Files: public/mock-backend/public/*
-Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2022 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: public/mock-backend/api/*
-Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2022 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: public/icons/*
-Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2022 The HedgeDoc developers (see AUTHORS file)
 License: LicenseRef-HedgeDoc-Icon-Usage-Guidelines
 
 Files: locales/*
-Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2022 The HedgeDoc developers (see AUTHORS file)
 License: CC-BY-SA-4.0
 
 Files: public/mock-backend/public/img/highres.jpg
@@ -24,15 +24,15 @@ Copyright: Vincent van Gogh
 License: CC0-1.0
 
 Files: public/index.html
-Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2022 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: public/robots.txt
-Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2022 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: .yarnrc.yml
-Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2022 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: .yarn/**
@@ -40,27 +40,27 @@ Copyright: Yarn contributors
 License: BSD-2-Clause
 
 Files: .gitattributes
-Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2022 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: .idea/**
-Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2022 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: netlify.toml
-Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2022 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: .netlify/*
-Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2022 The HedgeDoc developers (see AUTHORS file)
 License: CC0-1.0
 
 Files: .github/ISSUE_TEMPLATE/*.md
-Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2022 The HedgeDoc developers (see AUTHORS file)
 License: CC-BY-SA-4.0
 
 Files: .github/pull_request_template.md
-Copyright: 2021 The HedgeDoc developers (see AUTHORS file)
+Copyright: 2022 The HedgeDoc developers (see AUTHORS file)
 License: CC-BY-SA-4.0
 
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/cypress.json.license
+++ b/cypress.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/cypress/.eslintrc.json.license
+++ b/cypress/.eslintrc.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/cypress/fixtures/demo.png.license
+++ b/cypress/fixtures/demo.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/cypress/fixtures/history-2.json.license
+++ b/cypress/fixtures/history-2.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/cypress/fixtures/history.json.license
+++ b/cypress/fixtures/history.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/cypress/fixtures/import.md.license
+++ b/cypress/fixtures/import.md.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/cypress/fixtures/invalid-history.txt.license
+++ b/cypress/fixtures/invalid-history.txt.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/cypress/fixtures/languages.ts
+++ b/cypress/fixtures/languages.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/deleteNote.spec.ts
+++ b/cypress/integration/deleteNote.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/diagrams.spec.ts
+++ b/cypress/integration/diagrams.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/document-read-only-page.spec.ts
+++ b/cypress/integration/document-read-only-page.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/documentTitle.spec.ts
+++ b/cypress/integration/documentTitle.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/editorMode.spec.ts
+++ b/cypress/integration/editorMode.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/emoji.spec.ts
+++ b/cypress/integration/emoji.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/export.spec.ts
+++ b/cypress/integration/export.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/fileUpload.spec.ts
+++ b/cypress/integration/fileUpload.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/helpDialog.spec.ts
+++ b/cypress/integration/helpDialog.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/highlightedCodeBlock.spec.ts
+++ b/cypress/integration/highlightedCodeBlock.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/history.spec.ts
+++ b/cypress/integration/history.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/iframe-capsule.ts
+++ b/cypress/integration/iframe-capsule.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/import.spec.ts
+++ b/cypress/integration/import.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/intro.spec.ts
+++ b/cypress/integration/intro.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/language.spec.ts
+++ b/cypress/integration/language.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/link.spec.ts
+++ b/cypress/integration/link.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/linkEmbedder.spec.ts
+++ b/cypress/integration/linkEmbedder.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/linkSchemes.spec.ts
+++ b/cypress/integration/linkSchemes.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/maxLength.spec.ts
+++ b/cypress/integration/maxLength.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/motd.spec.ts
+++ b/cypress/integration/motd.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/profile.spec.ts
+++ b/cypress/integration/profile.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/quote-extra.spec.ts
+++ b/cypress/integration/quote-extra.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/renderer-mode.spec.ts
+++ b/cypress/integration/renderer-mode.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/shortcodes.spec.ts
+++ b/cypress/integration/shortcodes.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/signInButton.spec.ts
+++ b/cypress/integration/signInButton.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/slideshow-only-page.spec.ts
+++ b/cypress/integration/slideshow-only-page.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/splitter.spec.ts
+++ b/cypress/integration/splitter.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/taskLists.spec.ts
+++ b/cypress/integration/taskLists.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/word-count.spec.ts
+++ b/cypress/integration/word-count.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/integration/yamlArrayDeprecationMessage.spec.ts
+++ b/cypress/integration/yamlArrayDeprecationMessage.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/support/check-links.ts
+++ b/cypress/support/check-links.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/support/config.ts
+++ b/cypress/support/config.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/support/fill.ts
+++ b/cypress/support/fill.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/support/get-by-id.ts
+++ b/cypress/support/get-by-id.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/support/get-iframe-content.ts
+++ b/cypress/support/get-iframe-content.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/support/login.ts
+++ b/cypress/support/login.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/support/visit-test-editor.ts
+++ b/cypress/support/visit-test-editor.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/cypress/tsconfig.json.license
+++ b/cypress/tsconfig.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/global-styles/bootstrap-color-theme/_alert.scss
+++ b/global-styles/bootstrap-color-theme/_alert.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_badge.scss
+++ b/global-styles/bootstrap-color-theme/_badge.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_breadcrumb.scss
+++ b/global-styles/bootstrap-color-theme/_breadcrumb.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_buttons.scss
+++ b/global-styles/bootstrap-color-theme/_buttons.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_card.scss
+++ b/global-styles/bootstrap-color-theme/_card.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_carousel.scss
+++ b/global-styles/bootstrap-color-theme/_carousel.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_close.scss
+++ b/global-styles/bootstrap-color-theme/_close.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_code.scss
+++ b/global-styles/bootstrap-color-theme/_code.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_dropdown.scss
+++ b/global-styles/bootstrap-color-theme/_dropdown.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_forms.scss
+++ b/global-styles/bootstrap-color-theme/_forms.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_images.scss
+++ b/global-styles/bootstrap-color-theme/_images.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_input-group.scss
+++ b/global-styles/bootstrap-color-theme/_input-group.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_jumbotron.scss
+++ b/global-styles/bootstrap-color-theme/_jumbotron.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_list-group.scss
+++ b/global-styles/bootstrap-color-theme/_list-group.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_modal.scss
+++ b/global-styles/bootstrap-color-theme/_modal.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_nav.scss
+++ b/global-styles/bootstrap-color-theme/_nav.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_navbar.scss
+++ b/global-styles/bootstrap-color-theme/_navbar.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_pagination.scss
+++ b/global-styles/bootstrap-color-theme/_pagination.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_popover.scss
+++ b/global-styles/bootstrap-color-theme/_popover.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_progress.scss
+++ b/global-styles/bootstrap-color-theme/_progress.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_reboot.scss
+++ b/global-styles/bootstrap-color-theme/_reboot.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_spinners.scss
+++ b/global-styles/bootstrap-color-theme/_spinners.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_tables.scss
+++ b/global-styles/bootstrap-color-theme/_tables.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_toasts.scss
+++ b/global-styles/bootstrap-color-theme/_toasts.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_tooltip.scss
+++ b/global-styles/bootstrap-color-theme/_tooltip.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/_type.scss
+++ b/global-styles/bootstrap-color-theme/_type.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/include.scss
+++ b/global-styles/bootstrap-color-theme/include.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/utilities/_background.scss
+++ b/global-styles/bootstrap-color-theme/utilities/_background.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/utilities/_borders.scss
+++ b/global-styles/bootstrap-color-theme/utilities/_borders.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-color-theme/utilities/_text.scss
+++ b/global-styles/bootstrap-color-theme/utilities/_text.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/bootstrap-vendor/bootstrap.scss
+++ b/global-styles/bootstrap-vendor/bootstrap.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/button-inside.scss
+++ b/global-styles/button-inside.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/dark.scss
+++ b/global-styles/dark.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/highlight-js.scss
+++ b/global-styles/highlight-js.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/index.scss
+++ b/global-styles/index.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/markdown-tweaks.scss
+++ b/global-styles/markdown-tweaks.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/reveal.scss
+++ b/global-styles/reveal.scss
@@ -1,5 +1,5 @@
 /*!
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/typeahead.scss
+++ b/global-styles/typeahead.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/variables.dark.scss
+++ b/global-styles/variables.dark.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/variables.light.scss
+++ b/global-styles/variables.light.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/global-styles/variables.module.scss
+++ b/global-styles/variables.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/netlify/deploy-main.sh
+++ b/netlify/deploy-main.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/netlify/deploy-pr.sh
+++ b/netlify/deploy-pr.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/netlify/intro.md.license
+++ b/netlify/intro.md.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/netlify/motd.md.license
+++ b/netlify/motd.md.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/netlify/patch-files.sh
+++ b/netlify/patch-files.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+# SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/next-env.d.ts.license
+++ b/next-env.d.ts.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/package.json.license
+++ b/package.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/renovate.json.license
+++ b/renovate.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/auth/ldap.ts
+++ b/src/api/auth/ldap.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/auth/local.ts
+++ b/src/api/auth/local.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/config/types.d.ts
+++ b/src/api/config/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/group/types.d.ts
+++ b/src/api/group/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/history/dto-methods.ts
+++ b/src/api/history/dto-methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/history/types.d.ts
+++ b/src/api/history/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/me/index.ts
+++ b/src/api/me/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/media/index.ts
+++ b/src/api/media/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/notes/index.ts
+++ b/src/api/notes/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/notes/types.d.ts
+++ b/src/api/notes/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/revisions/index.ts
+++ b/src/api/revisions/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/revisions/types.d.ts
+++ b/src/api/revisions/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/tokens/index.ts
+++ b/src/api/tokens/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/tokens/types.d.ts
+++ b/src/api/tokens/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/users/index.ts
+++ b/src/api/users/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/users/types.d.ts
+++ b/src/api/users/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/application-loader/application-loader-error.ts
+++ b/src/components/application-loader/application-loader-error.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/application-loader/application-loader.module.scss
+++ b/src/components/application-loader/application-loader.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/application-loader/application-loader.tsx
+++ b/src/components/application-loader/application-loader.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/application-loader/initializers/fetch-frontend-config.ts
+++ b/src/components/application-loader/initializers/fetch-frontend-config.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/application-loader/initializers/fetch-motd.ts
+++ b/src/components/application-loader/initializers/fetch-motd.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/application-loader/initializers/index.ts
+++ b/src/components/application-loader/initializers/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/application-loader/initializers/load-dark-mode.ts
+++ b/src/components/application-loader/initializers/load-dark-mode.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/application-loader/initializers/setupI18n.ts
+++ b/src/components/application-loader/initializers/setupI18n.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/application-loader/loading-screen/animated-hedge-doc-logo/animations.module.scss
+++ b/src/components/application-loader/loading-screen/animated-hedge-doc-logo/animations.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/branding/branding.module.scss
+++ b/src/components/common/branding/branding.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/branding/branding.tsx
+++ b/src/components/common/branding/branding.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/cache/cache.test.ts
+++ b/src/components/common/cache/cache.test.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/cache/cache.ts
+++ b/src/components/common/cache/cache.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/copyable/copy-to-clipboard-button/copy-to-clipboard-button.tsx
+++ b/src/components/common/copyable/copy-to-clipboard-button/copy-to-clipboard-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/copyable/copyable-field/copyable-field.tsx
+++ b/src/components/common/copyable/copyable-field/copyable-field.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/countdown-button/countdown-button.tsx
+++ b/src/components/common/countdown-button/countdown-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/download/download.ts
+++ b/src/components/common/download/download.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/fields/current-password-field.tsx
+++ b/src/components/common/fields/current-password-field.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/fields/display-name-field.tsx
+++ b/src/components/common/fields/display-name-field.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/fields/fields.ts
+++ b/src/components/common/fields/fields.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/fields/new-password-field.tsx
+++ b/src/components/common/fields/new-password-field.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/fields/password-again-field.tsx
+++ b/src/components/common/fields/password-again-field.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/fields/username-field.tsx
+++ b/src/components/common/fields/username-field.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/fork-awesome/fork-awesome-icon.tsx
+++ b/src/components/common/fork-awesome/fork-awesome-icon.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/fork-awesome/fork-awesome-icons.ts
+++ b/src/components/common/fork-awesome/fork-awesome-icons.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/fork-awesome/fork-awesome-stack.tsx
+++ b/src/components/common/fork-awesome/fork-awesome-stack.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/fork-awesome/types.d.ts
+++ b/src/components/common/fork-awesome/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/hedge-doc-logo/hedge-doc-logo-with-text.tsx
+++ b/src/components/common/hedge-doc-logo/hedge-doc-logo-with-text.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/hedge-doc-logo/logo_color.svg
+++ b/src/components/common/hedge-doc-logo/logo_color.svg
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: LicenseRef-HedgeDoc-Icon-Usage-Guidelines
 -->

--- a/src/components/common/hedge-doc-logo/logo_text_bw_horizontal.svg
+++ b/src/components/common/hedge-doc-logo/logo_text_bw_horizontal.svg
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: LicenseRef-HedgeDoc-Icon-Usage-Guidelines
 -->

--- a/src/components/common/hedge-doc-logo/logo_text_color_vertical.svg
+++ b/src/components/common/hedge-doc-logo/logo_text_color_vertical.svg
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: LicenseRef-HedgeDoc-Icon-Usage-Guidelines
 -->

--- a/src/components/common/hedge-doc-logo/logo_text_wb_horizontal.svg
+++ b/src/components/common/hedge-doc-logo/logo_text_wb_horizontal.svg
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: LicenseRef-HedgeDoc-Icon-Usage-Guidelines
 -->

--- a/src/components/common/hljs/hljs.ts
+++ b/src/components/common/hljs/hljs.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/icon-button/icon-button.module.scss
+++ b/src/components/common/icon-button/icon-button.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/icon-button/icon-button.tsx
+++ b/src/components/common/icon-button/icon-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/icon-button/translated-icon-button.tsx
+++ b/src/components/common/icon-button/translated-icon-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/links/external-link.tsx
+++ b/src/components/common/links/external-link.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/links/internal-link.tsx
+++ b/src/components/common/links/internal-link.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/links/translated-external-link.tsx
+++ b/src/components/common/links/translated-external-link.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/links/translated-internal-link.tsx
+++ b/src/components/common/links/translated-internal-link.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/links/types.d.ts
+++ b/src/components/common/links/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/lock-button/lock-button.tsx
+++ b/src/components/common/lock-button/lock-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/modals/common-modal.tsx
+++ b/src/components/common/modals/common-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/modals/deletion-modal.tsx
+++ b/src/components/common/modals/deletion-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/motd-modal/motd-modal.tsx
+++ b/src/components/common/motd-modal/motd-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/number-range/number-range.ts
+++ b/src/components/common/number-range/number-range.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/pagination/pager-item.tsx
+++ b/src/components/common/pagination/pager-item.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/pagination/pager-pagination.tsx
+++ b/src/components/common/pagination/pager-pagination.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/pagination/pager.tsx
+++ b/src/components/common/pagination/pager.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/redirect-back.tsx
+++ b/src/components/common/redirect-back.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/redirect.tsx
+++ b/src/components/common/redirect.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/routing/not-found-error-screen.tsx
+++ b/src/components/common/routing/not-found-error-screen.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/show-if/show-if.tsx
+++ b/src/components/common/show-if/show-if.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/simple-alert/simple-alert-props.ts
+++ b/src/components/common/simple-alert/simple-alert-props.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/upload-image-mimetypes.ts
+++ b/src/components/common/upload-image-mimetypes.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/user-avatar/user-avatar.module.scss
+++ b/src/components/common/user-avatar/user-avatar.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/user-avatar/user-avatar.tsx
+++ b/src/components/common/user-avatar/user-avatar.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/common/wait-spinner/wait-spinner.tsx
+++ b/src/components/common/wait-spinner/wait-spinner.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/document-read-only-page/ErrorWhileLoadingNoteAlert.tsx
+++ b/src/components/document-read-only-page/ErrorWhileLoadingNoteAlert.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/document-read-only-page/LoadingNoteAlert.tsx
+++ b/src/components/document-read-only-page/LoadingNoteAlert.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/document-read-only-page/document-infobar.module.scss
+++ b/src/components/document-read-only-page/document-infobar.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/document-read-only-page/document-infobar.tsx
+++ b/src/components/document-read-only-page/document-infobar.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/document-read-only-page/document-read-only-page-content.tsx
+++ b/src/components/document-read-only-page/document-read-only-page-content.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/app-bar/app-bar.tsx
+++ b/src/components/editor-page/app-bar/app-bar.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/app-bar/dark-mode-button.tsx
+++ b/src/components/editor-page/app-bar/dark-mode-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/app-bar/editor-view-mode.tsx
+++ b/src/components/editor-page/app-bar/editor-view-mode.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/app-bar/help-button/cheatsheet-line.tsx
+++ b/src/components/editor-page/app-bar/help-button/cheatsheet-line.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/app-bar/help-button/cheatsheet-tab-content.tsx
+++ b/src/components/editor-page/app-bar/help-button/cheatsheet-tab-content.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/app-bar/help-button/cheatsheet.module.scss
+++ b/src/components/editor-page/app-bar/help-button/cheatsheet.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/app-bar/help-button/help-button.tsx
+++ b/src/components/editor-page/app-bar/help-button/help-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/app-bar/help-button/help-modal.tsx
+++ b/src/components/editor-page/app-bar/help-button/help-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/app-bar/help-button/links-tab-content.tsx
+++ b/src/components/editor-page/app-bar/help-button/links-tab-content.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/app-bar/help-button/shortcuts-tab-content.tsx
+++ b/src/components/editor-page/app-bar/help-button/shortcuts-tab-content.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/app-bar/navbar-branding.tsx
+++ b/src/components/editor-page/app-bar/navbar-branding.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/app-bar/new-note-button.tsx
+++ b/src/components/editor-page/app-bar/new-note-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/app-bar/read-only-mode-button.tsx
+++ b/src/components/editor-page/app-bar/read-only-mode-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/app-bar/slide-mode-button.tsx
+++ b/src/components/editor-page/app-bar/slide-mode-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/app-bar/sync-scroll-buttons/buttonIcon.inkscape.svg
+++ b/src/components/editor-page/app-bar/sync-scroll-buttons/buttonIcon.inkscape.svg
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0
 -->

--- a/src/components/editor-page/app-bar/sync-scroll-buttons/disabledScroll.svg
+++ b/src/components/editor-page/app-bar/sync-scroll-buttons/disabledScroll.svg
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0
 -->

--- a/src/components/editor-page/app-bar/sync-scroll-buttons/enabledScroll.svg
+++ b/src/components/editor-page/app-bar/sync-scroll-buttons/enabledScroll.svg
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0
 -->

--- a/src/components/editor-page/app-bar/sync-scroll-buttons/sync-scroll-buttons.module.scss
+++ b/src/components/editor-page/app-bar/sync-scroll-buttons/sync-scroll-buttons.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/app-bar/sync-scroll-buttons/sync-scroll-buttons.tsx
+++ b/src/components/editor-page/app-bar/sync-scroll-buttons/sync-scroll-buttons.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/document-bar/document-info/document-info-line-word-count.tsx
+++ b/src/components/editor-page/document-bar/document-info/document-info-line-word-count.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/document-bar/document-info/document-info-line.tsx
+++ b/src/components/editor-page/document-bar/document-info/document-info-line.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/document-bar/document-info/document-info-modal.tsx
+++ b/src/components/editor-page/document-bar/document-info/document-info-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/document-bar/document-info/document-info-time-line.tsx
+++ b/src/components/editor-page/document-bar/document-info/document-info-time-line.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/document-bar/document-info/time-from-now.tsx
+++ b/src/components/editor-page/document-bar/document-info/time-from-now.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/document-bar/document-info/unitalic-bold-text.tsx
+++ b/src/components/editor-page/document-bar/document-info/unitalic-bold-text.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/document-bar/permissions/permission-group-entry.tsx
+++ b/src/components/editor-page/document-bar/permissions/permission-group-entry.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/document-bar/permissions/permission-list.tsx
+++ b/src/components/editor-page/document-bar/permissions/permission-list.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/document-bar/permissions/permission-modal.tsx
+++ b/src/components/editor-page/document-bar/permissions/permission-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/document-bar/revisions/revision-modal-list-entry.module.scss
+++ b/src/components/editor-page/document-bar/revisions/revision-modal-list-entry.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/document-bar/revisions/revision-modal-list-entry.tsx
+++ b/src/components/editor-page/document-bar/revisions/revision-modal-list-entry.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/document-bar/revisions/revision-modal.module.scss
+++ b/src/components/editor-page/document-bar/revisions/revision-modal.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/document-bar/revisions/revision-modal.tsx
+++ b/src/components/editor-page/document-bar/revisions/revision-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/document-bar/revisions/utils.ts
+++ b/src/components/editor-page/document-bar/revisions/utils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/document-bar/share/share-modal.tsx
+++ b/src/components/editor-page/document-bar/share/share-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-document-renderer/editor-document-renderer.tsx
+++ b/src/components/editor-page/editor-document-renderer/editor-document-renderer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/extended-codemirror/codemirror.module.scss
+++ b/src/components/editor-page/editor-pane/extended-codemirror/codemirror.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/extended-codemirror/hints.scss
+++ b/src/components/editor-page/editor-pane/extended-codemirror/hints.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/find-regex-match-in-text.test.ts
+++ b/src/components/editor-page/editor-pane/find-regex-match-in-text.test.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/find-regex-match-in-text.ts
+++ b/src/components/editor-page/editor-pane/find-regex-match-in-text.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/hooks/use-apply-scroll-state.ts
+++ b/src/components/editor-page/editor-pane/hooks/use-apply-scroll-state.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/hooks/use-on-image-upload-from-renderer.ts
+++ b/src/components/editor-page/editor-pane/hooks/use-on-image-upload-from-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/max-length-warning/max-length-warning-modal.tsx
+++ b/src/components/editor-page/editor-pane/max-length-warning/max-length-warning-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/max-length-warning/max-length-warning.tsx
+++ b/src/components/editor-page/editor-pane/max-length-warning/max-length-warning.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/status-bar/cursor-position-info.tsx
+++ b/src/components/editor-page/editor-pane/status-bar/cursor-position-info.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/status-bar/number-of-lines-in-document-info.tsx
+++ b/src/components/editor-page/editor-pane/status-bar/number-of-lines-in-document-info.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/status-bar/remaining-characters-info.tsx
+++ b/src/components/editor-page/editor-pane/status-bar/remaining-characters-info.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/status-bar/selection-info.tsx
+++ b/src/components/editor-page/editor-pane/status-bar/selection-info.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/status-bar/separator-dash.tsx
+++ b/src/components/editor-page/editor-pane/status-bar/separator-dash.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/status-bar/status-bar.module.scss
+++ b/src/components/editor-page/editor-pane/status-bar/status-bar.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/status-bar/status-bar.tsx
+++ b/src/components/editor-page/editor-pane/status-bar/status-bar.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/table-extractor.test.ts
+++ b/src/components/editor-page/editor-pane/table-extractor.test.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/table-extractor.ts
+++ b/src/components/editor-page/editor-pane/table-extractor.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/tool-bar/emoji-picker/emoji-picker-button.tsx
+++ b/src/components/editor-page/editor-pane/tool-bar/emoji-picker/emoji-picker-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/tool-bar/emoji-picker/emoji-picker.module.scss
+++ b/src/components/editor-page/editor-pane/tool-bar/emoji-picker/emoji-picker.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/tool-bar/emoji-picker/emoji-picker.tsx
+++ b/src/components/editor-page/editor-pane/tool-bar/emoji-picker/emoji-picker.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/tool-bar/table-picker/custom-table-size-modal.tsx
+++ b/src/components/editor-page/editor-pane/tool-bar/table-picker/custom-table-size-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/tool-bar/table-picker/table-picker-button.tsx
+++ b/src/components/editor-page/editor-pane/tool-bar/table-picker/table-picker-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/tool-bar/table-picker/table-picker.module.scss
+++ b/src/components/editor-page/editor-pane/tool-bar/table-picker/table-picker.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/tool-bar/table-picker/table-size-picker-popover.tsx
+++ b/src/components/editor-page/editor-pane/tool-bar/table-picker/table-size-picker-popover.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/tool-bar/table-picker/table-size-text.tsx
+++ b/src/components/editor-page/editor-pane/tool-bar/table-picker/table-size-text.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/tool-bar/tool-bar.module.scss
+++ b/src/components/editor-page/editor-pane/tool-bar/tool-bar.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/tool-bar/tool-bar.tsx
+++ b/src/components/editor-page/editor-pane/tool-bar/tool-bar.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/tool-bar/upload-image-button.tsx
+++ b/src/components/editor-page/editor-pane/tool-bar/upload-image-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/tool-bar/utils/codefenceDetection.test.ts
+++ b/src/components/editor-page/editor-pane/tool-bar/utils/codefenceDetection.test.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/tool-bar/utils/codefenceDetection.ts
+++ b/src/components/editor-page/editor-pane/tool-bar/utils/codefenceDetection.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/tool-bar/utils/emojiUtils.ts
+++ b/src/components/editor-page/editor-pane/tool-bar/utils/emojiUtils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/tool-bar/utils/pasteHandlers.ts
+++ b/src/components/editor-page/editor-pane/tool-bar/utils/pasteHandlers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/editor-pane/upload-handler.ts
+++ b/src/components/editor-page/editor-pane/upload-handler.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/hooks/useEditorModeFromUrl.ts
+++ b/src/components/editor-page/hooks/useEditorModeFromUrl.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/hooks/useLoadNoteFromServer.ts
+++ b/src/components/editor-page/hooks/useLoadNoteFromServer.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/hooks/useUpdateLocalHistoryEntry.ts
+++ b/src/components/editor-page/hooks/useUpdateLocalHistoryEntry.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/hooks/useViewModeShortcuts.ts
+++ b/src/components/editor-page/hooks/useViewModeShortcuts.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/render-context/editor-to-renderer-communicator-context-provider.tsx
+++ b/src/components/editor-page/render-context/editor-to-renderer-communicator-context-provider.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/render-context/renderer-to-editor-communicator-context-provider.tsx
+++ b/src/components/editor-page/render-context/renderer-to-editor-communicator-context-provider.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/render-context/use-origin-from-config.ts
+++ b/src/components/editor-page/render-context/use-origin-from-config.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/renderer-pane/communicator-image-lightbox.tsx
+++ b/src/components/editor-page/renderer-pane/communicator-image-lightbox.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/renderer-pane/hooks/use-effect-on-render-type-change.ts
+++ b/src/components/editor-page/renderer-pane/hooks/use-effect-on-render-type-change.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/renderer-pane/hooks/use-force-render-page-url-on-iframe-load-callback.ts
+++ b/src/components/editor-page/renderer-pane/hooks/use-force-render-page-url-on-iframe-load-callback.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/renderer-pane/hooks/use-send-dark-mode-status-to-renderer.ts
+++ b/src/components/editor-page/renderer-pane/hooks/use-send-dark-mode-status-to-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/renderer-pane/hooks/use-send-frontmatter-info-from-redux-to-renderer.ts
+++ b/src/components/editor-page/renderer-pane/hooks/use-send-frontmatter-info-from-redux-to-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/renderer-pane/hooks/use-send-markdown-to-renderer.ts
+++ b/src/components/editor-page/renderer-pane/hooks/use-send-markdown-to-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/renderer-pane/hooks/use-send-scroll-state.ts
+++ b/src/components/editor-page/renderer-pane/hooks/use-send-scroll-state.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/renderer-pane/render-iframe.tsx
+++ b/src/components/editor-page/renderer-pane/render-iframe.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/renderer-pane/yaml-array-deprecation-alert.tsx
+++ b/src/components/editor-page/renderer-pane/yaml-array-deprecation-alert.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/delete-note-sidebar-entry/delete-note-modal.tsx
+++ b/src/components/editor-page/sidebar/delete-note-sidebar-entry/delete-note-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/delete-note-sidebar-entry/delete-note-sidebar-entry.tsx
+++ b/src/components/editor-page/sidebar/delete-note-sidebar-entry/delete-note-sidebar-entry.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/sidebar-button/sidebar-button.module.scss
+++ b/src/components/editor-page/sidebar/sidebar-button/sidebar-button.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/sidebar-button/sidebar-button.tsx
+++ b/src/components/editor-page/sidebar/sidebar-button/sidebar-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/sidebar-menu/sidebar-menu.module.scss
+++ b/src/components/editor-page/sidebar/sidebar-menu/sidebar-menu.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/sidebar-menu/sidebar-menu.tsx
+++ b/src/components/editor-page/sidebar/sidebar-menu/sidebar-menu.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/sidebar.tsx
+++ b/src/components/editor-page/sidebar/sidebar.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/specific-sidebar-entries/document-info-sidebar-entry.tsx
+++ b/src/components/editor-page/sidebar/specific-sidebar-entries/document-info-sidebar-entry.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/specific-sidebar-entries/export-markdown-sidebar-entry.tsx
+++ b/src/components/editor-page/sidebar/specific-sidebar-entries/export-markdown-sidebar-entry.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/specific-sidebar-entries/export-menu-sidebar-menu.tsx
+++ b/src/components/editor-page/sidebar/specific-sidebar-entries/export-menu-sidebar-menu.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/specific-sidebar-entries/import-markdown-sidebar-entry.tsx
+++ b/src/components/editor-page/sidebar/specific-sidebar-entries/import-markdown-sidebar-entry.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/specific-sidebar-entries/import-menu-sidebar-menu.tsx
+++ b/src/components/editor-page/sidebar/specific-sidebar-entries/import-menu-sidebar-menu.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry.tsx
+++ b/src/components/editor-page/sidebar/specific-sidebar-entries/permissions-sidebar-entry.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/specific-sidebar-entries/pin-note-sidebar-entry.tsx
+++ b/src/components/editor-page/sidebar/specific-sidebar-entries/pin-note-sidebar-entry.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/specific-sidebar-entries/revision-sidebar-entry.tsx
+++ b/src/components/editor-page/sidebar/specific-sidebar-entries/revision-sidebar-entry.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/specific-sidebar-entries/share-sidebar-entry.tsx
+++ b/src/components/editor-page/sidebar/specific-sidebar-entries/share-sidebar-entry.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/style/sidebar.module.scss
+++ b/src/components/editor-page/sidebar/style/sidebar.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/style/variables.scss
+++ b/src/components/editor-page/sidebar/style/variables.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/types.ts
+++ b/src/components/editor-page/sidebar/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/upload-input.tsx
+++ b/src/components/editor-page/sidebar/upload-input.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/user-line/user-line.module.scss
+++ b/src/components/editor-page/sidebar/user-line/user-line.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/user-line/user-line.tsx
+++ b/src/components/editor-page/sidebar/user-line/user-line.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/users-online-sidebar-menu/active-indicator.module.scss
+++ b/src/components/editor-page/sidebar/users-online-sidebar-menu/active-indicator.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/users-online-sidebar-menu/active-indicator.tsx
+++ b/src/components/editor-page/sidebar/users-online-sidebar-menu/active-indicator.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/users-online-sidebar-menu/online-counter.module.scss
+++ b/src/components/editor-page/sidebar/users-online-sidebar-menu/online-counter.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/sidebar/users-online-sidebar-menu/users-online-sidebar-menu.tsx
+++ b/src/components/editor-page/sidebar/users-online-sidebar-menu/users-online-sidebar-menu.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/splitter/hooks/use-adjusted-relative-split-value.ts
+++ b/src/components/editor-page/splitter/hooks/use-adjusted-relative-split-value.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/splitter/split-divider/split-divider.module.scss
+++ b/src/components/editor-page/splitter/split-divider/split-divider.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/splitter/split-divider/split-divider.tsx
+++ b/src/components/editor-page/splitter/split-divider/split-divider.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/splitter/splitter.module.scss
+++ b/src/components/editor-page/splitter/splitter.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/splitter/splitter.tsx
+++ b/src/components/editor-page/splitter/splitter.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/synced-scroll/scroll-props.ts
+++ b/src/components/editor-page/synced-scroll/scroll-props.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/synced-scroll/utils.ts
+++ b/src/components/editor-page/synced-scroll/utils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/table-of-contents/build-react-dom-from-toc-ast.tsx
+++ b/src/components/editor-page/table-of-contents/build-react-dom-from-toc-ast.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/table-of-contents/table-of-contents.module.scss
+++ b/src/components/editor-page/table-of-contents/table-of-contents.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/table-of-contents/table-of-contents.tsx
+++ b/src/components/editor-page/table-of-contents/table-of-contents.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/table-of-contents/toc-slugify.ts
+++ b/src/components/editor-page/table-of-contents/toc-slugify.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/editor-page/utils.ts
+++ b/src/components/editor-page/utils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/error-boundary/error-boundary.tsx
+++ b/src/components/error-boundary/error-boundary.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/entry-menu/delete-note-item.tsx
+++ b/src/components/history-page/entry-menu/delete-note-item.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/entry-menu/dropdown-item-with-deletion-modal.tsx
+++ b/src/components/history-page/entry-menu/dropdown-item-with-deletion-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/entry-menu/entry-menu.module.scss
+++ b/src/components/history-page/entry-menu/entry-menu.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/entry-menu/entry-menu.tsx
+++ b/src/components/history-page/entry-menu/entry-menu.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/entry-menu/remove-note-entry-item.tsx
+++ b/src/components/history-page/entry-menu/remove-note-entry-item.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-card/history-card-list.tsx
+++ b/src/components/history-page/history-card/history-card-list.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-card/history-card.module.scss
+++ b/src/components/history-page/history-card/history-card.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-card/history-card.tsx
+++ b/src/components/history-page/history-card/history-card.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-content/history-content.tsx
+++ b/src/components/history-page/history-content/history-content.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-table/history-table-row.tsx
+++ b/src/components/history-page/history-table/history-table-row.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-table/history-table.module.scss
+++ b/src/components/history-page/history-table/history-table.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-table/history-table.tsx
+++ b/src/components/history-page/history-table/history-table.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-toolbar/clear-history-button.tsx
+++ b/src/components/history-page/history-toolbar/clear-history-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-toolbar/export-history-button.tsx
+++ b/src/components/history-page/history-toolbar/export-history-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-toolbar/history-refresh-button.tsx
+++ b/src/components/history-page/history-toolbar/history-refresh-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-toolbar/history-toolbar-state.d.ts
+++ b/src/components/history-page/history-toolbar/history-toolbar-state.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-toolbar/history-toolbar.tsx
+++ b/src/components/history-page/history-toolbar/history-toolbar.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-toolbar/history-view-mode-toggle-button.tsx
+++ b/src/components/history-page/history-toolbar/history-view-mode-toggle-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-toolbar/import-history-button.tsx
+++ b/src/components/history-page/history-toolbar/import-history-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-toolbar/keyword-search-input.tsx
+++ b/src/components/history-page/history-toolbar/keyword-search-input.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-toolbar/sort-by-last-visited-button.tsx
+++ b/src/components/history-page/history-toolbar/sort-by-last-visited-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-toolbar/sort-by-title-button.tsx
+++ b/src/components/history-page/history-toolbar/sort-by-title-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-toolbar/tag-selection-input.tsx
+++ b/src/components/history-page/history-toolbar/tag-selection-input.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-toolbar/toolbar-context/history-toolbar-state-context-provider.tsx
+++ b/src/components/history-page/history-toolbar/toolbar-context/history-toolbar-state-context-provider.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-toolbar/toolbar-context/toolbar-context.d.ts
+++ b/src/components/history-page/history-toolbar/toolbar-context/toolbar-context.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-toolbar/toolbar-context/use-history-toolbar-state.tsx
+++ b/src/components/history-page/history-toolbar/toolbar-context/use-history-toolbar-state.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-toolbar/toolbar-context/use-sync-toolbar-state-to-url-effect.ts
+++ b/src/components/history-page/history-toolbar/toolbar-context/use-sync-toolbar-state-to-url-effect.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/history-toolbar/toolbar-filter-props.d.ts
+++ b/src/components/history-page/history-toolbar/toolbar-filter-props.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/pin-button/pin-button.module.scss
+++ b/src/components/history-page/pin-button/pin-button.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/pin-button/pin-button.tsx
+++ b/src/components/history-page/pin-button/pin-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/sort-button/sort-button.tsx
+++ b/src/components/history-page/sort-button/sort-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/use-history-entry-title.ts
+++ b/src/components/history-page/use-history-entry-title.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/history-page/utils.ts
+++ b/src/components/history-page/utils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/intro-page/cover-buttons/cover-buttons.module.scss
+++ b/src/components/intro-page/cover-buttons/cover-buttons.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/intro-page/cover-buttons/cover-buttons.tsx
+++ b/src/components/intro-page/cover-buttons/cover-buttons.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/intro-page/feature-links.tsx
+++ b/src/components/intro-page/feature-links.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/intro-page/hooks/use-intro-page-content.ts
+++ b/src/components/intro-page/hooks/use-intro-page-content.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/intro-page/intro-custom-content.tsx
+++ b/src/components/intro-page/intro-custom-content.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/intro-page/requests.ts
+++ b/src/components/intro-page/requests.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/footer/footer.tsx
+++ b/src/components/landing-layout/footer/footer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/footer/language-picker.tsx
+++ b/src/components/landing-layout/footer/language-picker.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/footer/powered-by-links.tsx
+++ b/src/components/landing-layout/footer/powered-by-links.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/footer/social-links.tsx
+++ b/src/components/landing-layout/footer/social-links.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/footer/version-info/version-info-link.tsx
+++ b/src/components/landing-layout/footer/version-info/version-info-link.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/footer/version-info/version-info-modal-column.tsx
+++ b/src/components/landing-layout/footer/version-info/version-info-modal-column.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/footer/version-info/version-info-modal.tsx
+++ b/src/components/landing-layout/footer/version-info/version-info-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/landing-layout.tsx
+++ b/src/components/landing-layout/landing-layout.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/navigation/header-bar/header-bar.tsx
+++ b/src/components/landing-layout/navigation/header-bar/header-bar.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/navigation/header-bar/header-nav-link.module.scss
+++ b/src/components/landing-layout/navigation/header-bar/header-nav-link.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/navigation/header-bar/header-nav-link.tsx
+++ b/src/components/landing-layout/navigation/header-bar/header-nav-link.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/navigation/new-guest-note-button.tsx
+++ b/src/components/landing-layout/navigation/new-guest-note-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/navigation/new-user-note-button.tsx
+++ b/src/components/landing-layout/navigation/new-user-note-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/navigation/sign-in-button.tsx
+++ b/src/components/landing-layout/navigation/sign-in-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/navigation/sign-out-dropdown-button.tsx
+++ b/src/components/landing-layout/navigation/sign-out-dropdown-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/landing-layout/navigation/user-dropdown.tsx
+++ b/src/components/landing-layout/navigation/user-dropdown.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/layout/base-head.tsx
+++ b/src/components/layout/base-head.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/login-page/auth/auth-error/auth-error.tsx
+++ b/src/components/login-page/auth/auth-error/auth-error.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/login-page/auth/fields/fields.ts
+++ b/src/components/login-page/auth/fields/fields.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/login-page/auth/fields/openid-field.tsx
+++ b/src/components/login-page/auth/fields/openid-field.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/login-page/auth/fields/password-field.tsx
+++ b/src/components/login-page/auth/fields/password-field.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/login-page/auth/fields/username-field.tsx
+++ b/src/components/login-page/auth/fields/username-field.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/login-page/auth/social-link-button/social-link-button.module.scss
+++ b/src/components/login-page/auth/social-link-button/social-link-button.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/login-page/auth/social-link-button/social-link-button.tsx
+++ b/src/components/login-page/auth/social-link-button/social-link-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/login-page/auth/utils.ts
+++ b/src/components/login-page/auth/utils.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/login-page/auth/via-ldap.tsx
+++ b/src/components/login-page/auth/via-ldap.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/login-page/auth/via-local.tsx
+++ b/src/components/login-page/auth/via-local.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/login-page/auth/via-one-click.module.scss
+++ b/src/components/login-page/auth/via-one-click.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/login-page/auth/via-one-click.tsx
+++ b/src/components/login-page/auth/via-one-click.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/common-markdown-renderer-props.ts
+++ b/src/components/markdown-renderer/common-markdown-renderer-props.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/document-markdown-renderer.tsx
+++ b/src/components/markdown-renderer/document-markdown-renderer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/hooks/use-convert-markdown-to-react-dom.ts
+++ b/src/components/markdown-renderer/hooks/use-convert-markdown-to-react-dom.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/hooks/use-extract-first-headline.ts
+++ b/src/components/markdown-renderer/hooks/use-extract-first-headline.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/hooks/use-markdown-extensions.ts
+++ b/src/components/markdown-renderer/hooks/use-markdown-extensions.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/hooks/use-on-ref-change.ts
+++ b/src/components/markdown-renderer/hooks/use-on-ref-change.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/hooks/use-reveal.ts
+++ b/src/components/markdown-renderer/hooks/use-reveal.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/invalid-yaml-alert.tsx
+++ b/src/components/markdown-renderer/invalid-yaml-alert.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/loading-slide.tsx
+++ b/src/components/markdown-renderer/loading-slide.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/abcjs/__snapshots__/abc-frame.test.tsx.snap
+++ b/src/components/markdown-renderer/markdown-extension/abcjs/__snapshots__/abc-frame.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/abcjs/abc-frame.tsx
+++ b/src/components/markdown-renderer/markdown-extension/abcjs/abc-frame.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/abcjs/abc.module.scss
+++ b/src/components/markdown-renderer/markdown-extension/abcjs/abc.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/abcjs/abcjs-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/abcjs/abcjs-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/alert-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/alert-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/blockquote/blockquote-border-color-node-preprocessor.ts
+++ b/src/components/markdown-renderer/markdown-extension/blockquote/blockquote-border-color-node-preprocessor.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/blockquote/blockquote-color-extra-tag-replacer.tsx
+++ b/src/components/markdown-renderer/markdown-extension/blockquote/blockquote-color-extra-tag-replacer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/blockquote/blockquote-extra-tag-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/blockquote/blockquote-extra-tag-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/blockquote/blockquote-extra-tag-markdown-it-plugin.test.ts
+++ b/src/components/markdown-renderer/markdown-extension/blockquote/blockquote-extra-tag-markdown-it-plugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/blockquote/blockquote-extra-tag-markdown-it-plugin.ts
+++ b/src/components/markdown-renderer/markdown-extension/blockquote/blockquote-extra-tag-markdown-it-plugin.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/blockquote/blockquote-extra-tag-replacer.tsx
+++ b/src/components/markdown-renderer/markdown-extension/blockquote/blockquote-extra-tag-replacer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/blockquote/parse-blockquote-extra-tag.ts
+++ b/src/components/markdown-renderer/markdown-extension/blockquote/parse-blockquote-extra-tag.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/csv/csv-parser.test.ts
+++ b/src/components/markdown-renderer/markdown-extension/csv/csv-parser.test.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/csv/csv-parser.ts
+++ b/src/components/markdown-renderer/markdown-extension/csv/csv-parser.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/csv/csv-replacer.tsx
+++ b/src/components/markdown-renderer/markdown-extension/csv/csv-replacer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/csv/csv-table-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/csv/csv-table-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/csv/csv-table.tsx
+++ b/src/components/markdown-renderer/markdown-extension/csv/csv-table.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/debugger-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/debugger-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/emoji/emoji-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/emoji/emoji-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/emoji/mapping.ts
+++ b/src/components/markdown-renderer/markdown-extension/emoji/mapping.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/flowchart/flowchart-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/flowchart/flowchart-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/flowchart/flowchart.tsx
+++ b/src/components/markdown-renderer/markdown-extension/flowchart/flowchart.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/generic-syntax-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/generic-syntax-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/gist/gist-frame.module.scss
+++ b/src/components/markdown-renderer/markdown-extension/gist/gist-frame.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/gist/gist-frame.tsx
+++ b/src/components/markdown-renderer/markdown-extension/gist/gist-frame.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/gist/gist-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/gist/gist-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/gist/replace-gist-link.ts
+++ b/src/components/markdown-renderer/markdown-extension/gist/replace-gist-link.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/gist/replace-legacy-gist-short-code.ts
+++ b/src/components/markdown-renderer/markdown-extension/gist/replace-legacy-gist-short-code.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/gist/use-resize-gist-frame.ts
+++ b/src/components/markdown-renderer/markdown-extension/gist/use-resize-gist-frame.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/graphviz/graphviz-frame.tsx
+++ b/src/components/markdown-renderer/markdown-extension/graphviz/graphviz-frame.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/graphviz/graphviz-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/graphviz/graphviz-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/headline-anchors-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/headline-anchors-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/highlighted-fence/highlighted-code-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/highlighted-fence/highlighted-code-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/highlighted-fence/highlighted-code-replacer.tsx
+++ b/src/components/markdown-renderer/markdown-extension/highlighted-fence/highlighted-code-replacer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/highlighted-fence/highlighted-code.module.scss
+++ b/src/components/markdown-renderer/markdown-extension/highlighted-fence/highlighted-code.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/highlighted-fence/highlighted-code.tsx
+++ b/src/components/markdown-renderer/markdown-extension/highlighted-fence/highlighted-code.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/iframe-capsule/iframe-capsule-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/iframe-capsule/iframe-capsule-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/iframe-capsule/iframe-capsule-replacer.tsx
+++ b/src/components/markdown-renderer/markdown-extension/iframe-capsule/iframe-capsule-replacer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/image-placeholder/add-line-to-placeholder-image-tags.ts
+++ b/src/components/markdown-renderer/markdown-extension/image-placeholder/add-line-to-placeholder-image-tags.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/image-placeholder/hooks/use-on-image-upload.ts
+++ b/src/components/markdown-renderer/markdown-extension/image-placeholder/hooks/use-on-image-upload.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/image-placeholder/hooks/use-placeholder-size-style.ts
+++ b/src/components/markdown-renderer/markdown-extension/image-placeholder/hooks/use-placeholder-size-style.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/image-placeholder/image-placeholder-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/image-placeholder/image-placeholder-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/image-placeholder/image-placeholder-replacer.tsx
+++ b/src/components/markdown-renderer/markdown-extension/image-placeholder/image-placeholder-replacer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/image-placeholder/image-placeholder.module.scss
+++ b/src/components/markdown-renderer/markdown-extension/image-placeholder/image-placeholder.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/image-placeholder/image-placeholder.tsx
+++ b/src/components/markdown-renderer/markdown-extension/image-placeholder/image-placeholder.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/image-placeholder/utils/build-placeholder-size-css.test.ts
+++ b/src/components/markdown-renderer/markdown-extension/image-placeholder/utils/build-placeholder-size-css.test.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/image-placeholder/utils/build-placeholder-size-css.ts
+++ b/src/components/markdown-renderer/markdown-extension/image-placeholder/utils/build-placeholder-size-css.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/image/image-lightbox-modal.tsx
+++ b/src/components/markdown-renderer/markdown-extension/image/image-lightbox-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/image/lightbox.module.scss
+++ b/src/components/markdown-renderer/markdown-extension/image/lightbox.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/image/proxy-image-frame.tsx
+++ b/src/components/markdown-renderer/markdown-extension/image/proxy-image-frame.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/image/proxy-image-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/image/proxy-image-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/image/proxy-image-replacer.tsx
+++ b/src/components/markdown-renderer/markdown-extension/image/proxy-image-replacer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/katex/katex-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/katex/katex-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/katex/katex-replacer.tsx
+++ b/src/components/markdown-renderer/markdown-extension/katex/katex-replacer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/legacy-short-codes/legacy-shortcodes-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/legacy-short-codes/legacy-shortcodes-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/legacy-short-codes/replace-legacy-pdf-short-code.ts
+++ b/src/components/markdown-renderer/markdown-extension/legacy-short-codes/replace-legacy-pdf-short-code.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/legacy-short-codes/replace-legacy-slideshare-short-code.ts
+++ b/src/components/markdown-renderer/markdown-extension/legacy-short-codes/replace-legacy-slideshare-short-code.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/legacy-short-codes/replace-legacy-speakerdeck-short-code.ts
+++ b/src/components/markdown-renderer/markdown-extension/legacy-short-codes/replace-legacy-speakerdeck-short-code.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/linemarker/add-line-marker-markdown-it-plugin.ts
+++ b/src/components/markdown-renderer/markdown-extension/linemarker/add-line-marker-markdown-it-plugin.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/linemarker/linemarker-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/linemarker/linemarker-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/linemarker/linemarker-replacer.tsx
+++ b/src/components/markdown-renderer/markdown-extension/linemarker/linemarker-replacer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/linemarker/types.d.ts
+++ b/src/components/markdown-renderer/markdown-extension/linemarker/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/link-replacer/anchor-node-preprocessor.ts
+++ b/src/components/markdown-renderer/markdown-extension/link-replacer/anchor-node-preprocessor.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/link-replacer/jump-anchor-replacer.tsx
+++ b/src/components/markdown-renderer/markdown-extension/link-replacer/jump-anchor-replacer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/link-replacer/jump-anchor.tsx
+++ b/src/components/markdown-renderer/markdown-extension/link-replacer/jump-anchor.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/link-replacer/link-adjustment-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/link-replacer/link-adjustment-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/linkify-fix-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/linkify-fix-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/markmap/markmap-frame.tsx
+++ b/src/components/markdown-renderer/markdown-extension/markmap/markmap-frame.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/markmap/markmap-loader.ts
+++ b/src/components/markdown-renderer/markdown-extension/markmap/markmap-loader.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/markmap/markmap-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/markmap/markmap-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/mermaid/mermaid-chart.tsx
+++ b/src/components/markdown-renderer/markdown-extension/mermaid/mermaid-chart.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/mermaid/mermaid-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/mermaid/mermaid-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/mermaid/mermaid.module.scss
+++ b/src/components/markdown-renderer/markdown-extension/mermaid/mermaid.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/plantuml/plantuml-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/plantuml/plantuml-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/plantuml/plantuml-not-configured-alert.tsx
+++ b/src/components/markdown-renderer/markdown-extension/plantuml/plantuml-not-configured-alert.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/plantuml/plantuml-not-configured-component-replacer.tsx
+++ b/src/components/markdown-renderer/markdown-extension/plantuml/plantuml-not-configured-component-replacer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/reveal/process-reveal-comment-nodes.ts
+++ b/src/components/markdown-renderer/markdown-extension/reveal/process-reveal-comment-nodes.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/reveal/reveal-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/reveal/reveal-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/reveal/reveal-sections.ts
+++ b/src/components/markdown-renderer/markdown-extension/reveal/reveal-sections.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/sanitizer/dom-purifier-node-preprocessor.ts
+++ b/src/components/markdown-renderer/markdown-extension/sanitizer/dom-purifier-node-preprocessor.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/sanitizer/sanitizer-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/sanitizer/sanitizer-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/sequence-diagram/deprecation-warning.tsx
+++ b/src/components/markdown-renderer/markdown-extension/sequence-diagram/deprecation-warning.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/sequence-diagram/sequence-diagram-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/sequence-diagram/sequence-diagram-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/sequence-diagram/sequence-diagram.tsx
+++ b/src/components/markdown-renderer/markdown-extension/sequence-diagram/sequence-diagram.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/spoiler-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/spoiler-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/table-of-contents-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/table-of-contents-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/task-list/task-list-checkbox.tsx
+++ b/src/components/markdown-renderer/markdown-extension/task-list/task-list-checkbox.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/task-list/task-list-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/task-list/task-list-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/task-list/task-list-replacer.tsx
+++ b/src/components/markdown-renderer/markdown-extension/task-list/task-list-replacer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/upload-indicating-image-frame/upload-indicating-frame.tsx
+++ b/src/components/markdown-renderer/markdown-extension/upload-indicating-image-frame/upload-indicating-frame.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/upload-indicating-image-frame/upload-indicating-image-frame-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/upload-indicating-image-frame/upload-indicating-image-frame-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/upload-indicating-image-frame/upload-indicating-image-frame-replacer.tsx
+++ b/src/components/markdown-renderer/markdown-extension/upload-indicating-image-frame/upload-indicating-image-frame-replacer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/vega-lite/vega-lite-chart.tsx
+++ b/src/components/markdown-renderer/markdown-extension/vega-lite/vega-lite-chart.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/vega-lite/vega-lite-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/vega-lite/vega-lite-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/vimeo/replace-legacy-vimeo-short-code.ts
+++ b/src/components/markdown-renderer/markdown-extension/vimeo/replace-legacy-vimeo-short-code.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/vimeo/replace-vimeo-link.ts
+++ b/src/components/markdown-renderer/markdown-extension/vimeo/replace-vimeo-link.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/vimeo/vimeo-frame.tsx
+++ b/src/components/markdown-renderer/markdown-extension/vimeo/vimeo-frame.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/vimeo/vimeo-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/vimeo/vimeo-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/youtube/replace-legacy-youtube-short-code.ts
+++ b/src/components/markdown-renderer/markdown-extension/youtube/replace-legacy-youtube-short-code.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/youtube/replace-youtube-link.ts
+++ b/src/components/markdown-renderer/markdown-extension/youtube/replace-youtube-link.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/youtube/youtube-frame.tsx
+++ b/src/components/markdown-renderer/markdown-extension/youtube/youtube-frame.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/markdown-extension/youtube/youtube-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/youtube/youtube-markdown-extension.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/node-preprocessors/node-processor.ts
+++ b/src/components/markdown-renderer/node-preprocessors/node-processor.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/node-preprocessors/traveler-node-processor.ts
+++ b/src/components/markdown-renderer/node-preprocessors/traveler-node-processor.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/click-shield/click-shield.module.scss
+++ b/src/components/markdown-renderer/replace-components/click-shield/click-shield.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/click-shield/click-shield.tsx
+++ b/src/components/markdown-renderer/replace-components/click-shield/click-shield.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/code-block-component-replacer.ts
+++ b/src/components/markdown-renderer/replace-components/code-block-component-replacer.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/component-replacer.ts
+++ b/src/components/markdown-renderer/replace-components/component-replacer.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/replace-components/custom-tag-with-id-component-replacer.ts
+++ b/src/components/markdown-renderer/replace-components/custom-tag-with-id-component-replacer.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/slideshow-markdown-renderer.tsx
+++ b/src/components/markdown-renderer/slideshow-markdown-renderer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/utils/calculate-line-marker-positions.ts
+++ b/src/components/markdown-renderer/utils/calculate-line-marker-positions.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/utils/line-id-mapper.test.ts
+++ b/src/components/markdown-renderer/utils/line-id-mapper.test.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/utils/line-id-mapper.ts
+++ b/src/components/markdown-renderer/utils/line-id-mapper.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/utils/node-to-react-transformer.test.tsx
+++ b/src/components/markdown-renderer/utils/node-to-react-transformer.test.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/markdown-renderer/utils/node-to-react-transformer.tsx
+++ b/src/components/markdown-renderer/utils/node-to-react-transformer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/notifications/notifications.module.scss
+++ b/src/components/notifications/notifications.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/notifications/ui-notification-toast.tsx
+++ b/src/components/notifications/ui-notification-toast.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/notifications/ui-notifications.tsx
+++ b/src/components/notifications/ui-notifications.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/profile-page/access-tokens/access-token-created-modal.tsx
+++ b/src/components/profile-page/access-tokens/access-token-created-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/profile-page/access-tokens/access-token-creation-form/access-token-creation-form-expiry-field.tsx
+++ b/src/components/profile-page/access-tokens/access-token-creation-form/access-token-creation-form-expiry-field.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/profile-page/access-tokens/access-token-creation-form/access-token-creation-form-field.d.ts
+++ b/src/components/profile-page/access-tokens/access-token-creation-form/access-token-creation-form-field.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/profile-page/access-tokens/access-token-creation-form/access-token-creation-form-label-field.tsx
+++ b/src/components/profile-page/access-tokens/access-token-creation-form/access-token-creation-form-label-field.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/profile-page/access-tokens/access-token-creation-form/access-token-creation-form-submit-button.tsx
+++ b/src/components/profile-page/access-tokens/access-token-creation-form/access-token-creation-form-submit-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/profile-page/access-tokens/access-token-creation-form/access-token-creation-form.tsx
+++ b/src/components/profile-page/access-tokens/access-token-creation-form/access-token-creation-form.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/profile-page/access-tokens/access-token-creation-form/hooks/use-expiry-dates.ts
+++ b/src/components/profile-page/access-tokens/access-token-creation-form/hooks/use-expiry-dates.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/profile-page/access-tokens/access-token-creation-form/hooks/use-on-create-token.ts
+++ b/src/components/profile-page/access-tokens/access-token-creation-form/hooks/use-on-create-token.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/profile-page/access-tokens/access-token-deletion-modal.tsx
+++ b/src/components/profile-page/access-tokens/access-token-deletion-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/profile-page/access-tokens/access-token-list-entry.tsx
+++ b/src/components/profile-page/access-tokens/access-token-list-entry.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/profile-page/access-tokens/profile-access-tokens.tsx
+++ b/src/components/profile-page/access-tokens/profile-access-tokens.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/profile-page/account-management/account-deletion-modal.tsx
+++ b/src/components/profile-page/account-management/account-deletion-modal.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/profile-page/account-management/profile-account-management.tsx
+++ b/src/components/profile-page/account-management/profile-account-management.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/profile-page/settings/profile-change-password.tsx
+++ b/src/components/profile-page/settings/profile-change-password.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/profile-page/settings/profile-display-name.tsx
+++ b/src/components/profile-page/settings/profile-display-name.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/register-page/register-error/register-error.tsx
+++ b/src/components/register-page/register-error/register-error.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/register-page/register-infos/register-infos.tsx
+++ b/src/components/register-page/register-infos/register-infos.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/hooks/sync-scroll/use-document-sync-scrolling.ts
+++ b/src/components/render-page/hooks/sync-scroll/use-document-sync-scrolling.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/hooks/sync-scroll/use-on-user-scroll.ts
+++ b/src/components/render-page/hooks/sync-scroll/use-on-user-scroll.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/hooks/sync-scroll/use-scroll-to-line-mark.ts
+++ b/src/components/render-page/hooks/sync-scroll/use-scroll-to-line-mark.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/hooks/use-image-click-handler.ts
+++ b/src/components/render-page/hooks/use-image-click-handler.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/iframe-markdown-renderer.tsx
+++ b/src/components/render-page/iframe-markdown-renderer.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/markdown-document.module.scss
+++ b/src/components/render-page/markdown-document.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/markdown-document.tsx
+++ b/src/components/render-page/markdown-document.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/markdown-toc-button/markdown-toc-button.module.scss
+++ b/src/components/render-page/markdown-toc-button/markdown-toc-button.module.scss
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/markdown-toc-button/table-of-contents-hovering-button.tsx
+++ b/src/components/render-page/markdown-toc-button/table-of-contents-hovering-button.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/width-based-table-of-contents.tsx
+++ b/src/components/render-page/width-based-table-of-contents.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/window-post-message-communicator/editor-to-renderer-communicator.ts
+++ b/src/components/render-page/window-post-message-communicator/editor-to-renderer-communicator.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/window-post-message-communicator/hooks/use-editor-receive-handler.ts
+++ b/src/components/render-page/window-post-message-communicator/hooks/use-editor-receive-handler.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/window-post-message-communicator/hooks/use-effect-on-renderer-ready.ts
+++ b/src/components/render-page/window-post-message-communicator/hooks/use-effect-on-renderer-ready.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/window-post-message-communicator/hooks/use-is-renderer-ready.ts
+++ b/src/components/render-page/window-post-message-communicator/hooks/use-is-renderer-ready.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/window-post-message-communicator/hooks/use-renderer-receive-handler.ts
+++ b/src/components/render-page/window-post-message-communicator/hooks/use-renderer-receive-handler.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/window-post-message-communicator/hooks/use-send-to-renderer.ts
+++ b/src/components/render-page/window-post-message-communicator/hooks/use-send-to-renderer.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/window-post-message-communicator/renderer-to-editor-communicator.ts
+++ b/src/components/render-page/window-post-message-communicator/renderer-to-editor-communicator.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/window-post-message-communicator/rendering-message.ts
+++ b/src/components/render-page/window-post-message-communicator/rendering-message.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/window-post-message-communicator/window-post-message-communicator.ts
+++ b/src/components/render-page/window-post-message-communicator/window-post-message-communicator.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/render-page/word-counter.ts
+++ b/src/components/render-page/word-counter.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/components/slide-show-page/slide-show-page-content.tsx
+++ b/src/components/slide-show-page/slide-show-page-content.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-abbr/index.d.ts
+++ b/src/external-types/markdown-it-abbr/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-deflist/index.d.ts
+++ b/src/external-types/markdown-it-deflist/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-emoji/index.d.ts
+++ b/src/external-types/markdown-it-emoji/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-emoji/interface.d.ts
+++ b/src/external-types/markdown-it-emoji/interface.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-footnote/index.d.ts
+++ b/src/external-types/markdown-it-footnote/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-ins/index.d.ts
+++ b/src/external-types/markdown-it-ins/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-linkify/index.d.ts
+++ b/src/external-types/markdown-it-linkify/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-mark/index.d.ts
+++ b/src/external-types/markdown-it-mark/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-mathjax/index.d.ts
+++ b/src/external-types/markdown-it-mathjax/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-mathjax/interface.ts
+++ b/src/external-types/markdown-it-mathjax/interface.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-regex/index.d.ts
+++ b/src/external-types/markdown-it-regex/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-regex/interface.ts
+++ b/src/external-types/markdown-it-regex/interface.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-sub/index.d.ts
+++ b/src/external-types/markdown-it-sub/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markdown-it-sup/index.d.ts
+++ b/src/external-types/markdown-it-sup/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/markmap-lib/index.d.ts
+++ b/src/external-types/markmap-lib/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/external-types/reveal.js/index.d.ts
+++ b/src/external-types/reveal.js/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/hooks/common/use-app-title.ts
+++ b/src/hooks/common/use-app-title.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/hooks/common/use-application-state.ts
+++ b/src/hooks/common/use-application-state.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/hooks/common/use-apply-dark-mode.ts
+++ b/src/hooks/common/use-apply-dark-mode.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/hooks/common/use-array-string-url-parameter.ts
+++ b/src/hooks/common/use-array-string-url-parameter.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/hooks/common/use-backend-base-url.ts
+++ b/src/hooks/common/use-backend-base-url.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/hooks/common/use-customize-assets-url.ts
+++ b/src/hooks/common/use-customize-assets-url.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/hooks/common/use-frontend-base-url.ts
+++ b/src/hooks/common/use-frontend-base-url.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/hooks/common/use-is-dark-mode-activated.ts
+++ b/src/hooks/common/use-is-dark-mode-activated.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/hooks/common/use-note-markdown-content.ts
+++ b/src/hooks/common/use-note-markdown-content.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/hooks/common/use-note-title.ts
+++ b/src/hooks/common/use-note-title.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/hooks/common/use-on-input-change.ts
+++ b/src/hooks/common/use-on-input-change.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/hooks/common/use-single-string-url-parameter.ts
+++ b/src/hooks/common/use-single-string-url-parameter.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/hooks/common/use-trimmed-note-markdown-content-without-frontmatter.ts
+++ b/src/hooks/common/use-trimmed-note-markdown-content-without-frontmatter.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/links.json.license
+++ b/src/links.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/pages/[id].tsx
+++ b/src/pages/[id].tsx
@@ -1,5 +1,5 @@
 /*
- SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
  SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,5 @@
 /*
- SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
  SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -1,5 +1,5 @@
 /*
- SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
  SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/pages/intro.tsx
+++ b/src/pages/intro.tsx
@@ -1,5 +1,5 @@
 /*
- SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
  SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,5 +1,5 @@
 /*
- SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
  SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/pages/n/[id].tsx
+++ b/src/pages/n/[id].tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/pages/p/[id].tsx
+++ b/src/pages/p/[id].tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,5 +1,5 @@
 /*
- SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
  SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/pages/render.tsx
+++ b/src/pages/render.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/pages/s/[id].tsx
+++ b/src/pages/s/[id].tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/api-url/methods.ts
+++ b/src/redux/api-url/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/api-url/reducers.ts
+++ b/src/redux/api-url/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/api-url/types.ts
+++ b/src/redux/api-url/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/application-state.d.ts
+++ b/src/redux/application-state.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/config/methods.ts
+++ b/src/redux/config/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/config/reducers.ts
+++ b/src/redux/config/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/config/types.ts
+++ b/src/redux/config/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/dark-mode/methods.ts
+++ b/src/redux/dark-mode/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/dark-mode/reducers.ts
+++ b/src/redux/dark-mode/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/dark-mode/types.ts
+++ b/src/redux/dark-mode/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/editor/methods.ts
+++ b/src/redux/editor/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/editor/reducers.ts
+++ b/src/redux/editor/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/editor/types.ts
+++ b/src/redux/editor/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/history/methods.ts
+++ b/src/redux/history/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/history/reducers.ts
+++ b/src/redux/history/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/history/types.ts
+++ b/src/redux/history/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/motd/methods.ts
+++ b/src/redux/motd/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/motd/reducers.ts
+++ b/src/redux/motd/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/motd/types.ts
+++ b/src/redux/motd/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/note-details/frontmatter-extractor/extractor.test.ts
+++ b/src/redux/note-details/frontmatter-extractor/extractor.test.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/note-details/frontmatter-extractor/extractor.ts
+++ b/src/redux/note-details/frontmatter-extractor/extractor.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/note-details/frontmatter-extractor/types.d.ts
+++ b/src/redux/note-details/frontmatter-extractor/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/note-details/initial-state.ts
+++ b/src/redux/note-details/initial-state.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/note-details/methods.ts
+++ b/src/redux/note-details/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/note-details/raw-note-frontmatter-parser/parser.test.ts
+++ b/src/redux/note-details/raw-note-frontmatter-parser/parser.test.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/note-details/raw-note-frontmatter-parser/parser.ts
+++ b/src/redux/note-details/raw-note-frontmatter-parser/parser.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/note-details/raw-note-frontmatter-parser/types.d.ts
+++ b/src/redux/note-details/raw-note-frontmatter-parser/types.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/note-details/reducer.ts
+++ b/src/redux/note-details/reducer.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/note-details/types.ts
+++ b/src/redux/note-details/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/note-details/types/iso6391.ts
+++ b/src/redux/note-details/types/iso6391.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/note-details/types/note-details.ts
+++ b/src/redux/note-details/types/note-details.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/note-details/types/slide-show-options.d.ts
+++ b/src/redux/note-details/types/slide-show-options.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/reducers.ts
+++ b/src/redux/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/renderer-status/methods.ts
+++ b/src/redux/renderer-status/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/renderer-status/reducers.ts
+++ b/src/redux/renderer-status/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/renderer-status/types.ts
+++ b/src/redux/renderer-status/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/ui-notifications/methods.ts
+++ b/src/redux/ui-notifications/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/ui-notifications/reducers.ts
+++ b/src/redux/ui-notifications/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/ui-notifications/types.ts
+++ b/src/redux/ui-notifications/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/user/methods.ts
+++ b/src/redux/user/methods.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/user/reducers.ts
+++ b/src/redux/user/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/redux/user/types.ts
+++ b/src/redux/user/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/utils/cypress-attribute.ts
+++ b/src/utils/cypress-attribute.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/utils/is-client-side-rendering.ts
+++ b/src/utils/is-client-side-rendering.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/utils/test-modes.ts
+++ b/src/utils/test-modes.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/version.json.license
+++ b/src/version.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/tsconfig.json.license
+++ b/tsconfig.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0

--- a/yarn.lock.license
+++ b/yarn.lock.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
 
 SPDX-License-Identifier: CC0-1.0


### PR DESCRIPTION
### Component/Part
Everything

### Description
This PR changes the year in the copyright of every file to 2022.

### Steps
- [x] Added implementation
- [x] Added / updated tests
- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
