### PR TITLE
Removes the github deployment api from the main branch deployment

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -43,31 +43,7 @@ jobs:
       - name: Remove Next.js cache to avoid it being deployed
         run: rm -r .next/cache
 
-      - name: Mark GitHub deployment as started
-        uses: bobheadxi/deployments@v1.1.0
-        id: github-deployment
-        with:
-          step: start
-          token: ${{ secrets.GITHUB_TOKEN }}
-          env: "Latest main"
-          override: true
-          ref: ${{ github.ref }}
-
       - name: Run netlify CLI deployment
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         run: bash netlify/deploy-main.sh "${{ github.event.head_commit.id }}" "${{ github.event.head_commit.message }}"
-        id: netlify-result
-
-      - name: Mark GitHub deployment as finished
-        if: always()
-        uses: bobheadxi/deployments@v1.1.0
-        with:
-          step: finish
-          token: ${{ secrets.GITHUB_TOKEN }}
-          env_url: ${{ steps.netlify-result.outputs.url }}
-          env: ${{ steps.github-deployment.outputs.env }}
-          logs: ${{ steps.netlify-result.outputs.logs }}
-          status: ${{ job.status }}
-          deployment_id: ${{ steps.github-deployment.outputs.deployment_id }}
-          override: true


### PR DESCRIPTION
### Component/Part
Main branch deployment

### Description
The main branch deployment is broken because the github deployment api can't handle the number of states of the main branch.
This PR removes the deployment api requests from the main deployment workflow so it doesn't crash anymore and executes the netfliy cli again.

![image](https://user-images.githubusercontent.com/6124140/162036333-2b9246bd-abfd-488c-a44d-1c24cd5cd157.png)


The deployment API is useful to see where I can find the current deployment of a branch. It shouldn't hurt us a lot because the URL for the main branch is always the same: https://hedgedoc.dev


### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
