### PR TITLE
Remove Firefox from CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [ 'chrome', 'firefox' ]
+        browser: [ 'chrome' ]
         containers: [ 1, 2, 3, 4, 5 ]
     steps:
       - name: Check out repo


### PR DESCRIPTION
### Component/Part
CI

### Description
Okay I'm just done. Firefox in our current CI is just the WORST. It is slower than chrome and crashes A LOT! Like really! The e2e workflows of some PRs have to run 4 or 5 times because firefox decides to just loose the connection. 
This may also be caused by the performance of GHA, but right now it's easier to (temporaly) remove firefox than switching to a whole new CI.
Just to be clear: I know that this step isn't optimal. I know that a huge part of our community uses firefox. But right now the flakiness of the firefox CI runs drives me crazy!
At the moment we need the e2e tests just for our development to make sure that we don't accidentally break something.
We can readd firefox again when it's stable to use. Or when we have shifted enough of the e2e tests to jest. It would be nice to test other browsers (like safari or edge) as well.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
