### PR TITLE
Remove duplicated badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 ![test, build](https://github.com/hedgedoc/react-client/workflows/test,%20build/badge.svg)
 ![e2e](https://github.com/hedgedoc/react-client/workflows/e2e/badge.svg)
 ![lint](https://github.com/hedgedoc/react-client/workflows/lint/badge.svg)
-![lint](https://github.com/hedgedoc/react-client/workflows/lint/badge.svg)
 [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/hedgedoc/react-client.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/hedgedoc/react-client/context:javascript)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/hedgedoc/react-client.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/hedgedoc/react-client/alerts/)
 


### PR DESCRIPTION
### Component/Part
project README

### Description
This removes the duplicated "lint" badge in the README. This probably originated from the time when lint and prettier checks were two workflows.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated documentation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
none
