### PR TITLE
Update Cypress browsers to node16.13.2-chrome100-ff98

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # renovate: datasource=docker depName=cypress/browsers versioning=docker
-      image: cypress/browsers:node16.13.2-chrome97-ff96
+      image: cypress/browsers:node16.13.2-chrome100-ff98
       options: --user 1001 --shm-size=2g
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Component/Part
E2E Workflow

### Description
This PR updates the cypress browsers image because renovate can't do that.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
