### PR TITLE
Create store using redux-toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@matejmazur/react-katex": "3.1.3",
     "@react-hook/resize-observer": "1.2.5",
     "@redux-devtools/core": "3.12.0",
+    "@reduxjs/toolkit": "1.8.1",
     "@svgr/webpack": "6.2.1",
     "@uiw/react-codemirror": "4.7.0",
     "abcjs": "6.0.2",

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { createStore } from 'redux'
-import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly'
 import { allReducers } from './reducers'
 import type { ApplicationState } from './application-state'
+import { configureStore } from '@reduxjs/toolkit'
+import { isDevMode } from '../utils/test-modes'
 
-export const store = createStore(allReducers, composeWithDevTools())
+export const store = configureStore({
+  reducer: allReducers,
+  devTools: isDevMode
+})
 
 export const getGlobalState = (): ApplicationState => store.getState()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2076,6 +2076,7 @@ __metadata:
     "@next/bundle-analyzer": 12.1.5
     "@react-hook/resize-observer": 1.2.5
     "@redux-devtools/core": 3.12.0
+    "@reduxjs/toolkit": 1.8.1
     "@svgr/webpack": 6.2.1
     "@testing-library/cypress": 8.0.2
     "@testing-library/jest-dom": 5.16.4
@@ -3499,6 +3500,26 @@ __metadata:
   peerDependencies:
     redux: ^3.4.0 || ^4.0.0
   checksum: b84b7e2779a829d4a0807e983b00819183e4cf63056ecf8d6ef59685119f2f9dc32eb6813e3c06bc1424ebb9f33f2ff45bad66521dd2f0234bba2103e85e6423
+  languageName: node
+  linkType: hard
+
+"@reduxjs/toolkit@npm:1.8.1":
+  version: 1.8.1
+  resolution: "@reduxjs/toolkit@npm:1.8.1"
+  dependencies:
+    immer: ^9.0.7
+    redux: ^4.1.2
+    redux-thunk: ^2.4.1
+    reselect: ^4.1.5
+  peerDependencies:
+    react: ^16.9.0 || ^17.0.0 || ^18
+    react-redux: ^7.2.1 || ^8.0.0-beta
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-redux:
+      optional: true
+  checksum: be5cdea975a8a631fe2d88cafc7077554c7bc3621a4a7031556cc17e5dec26359018f2614c325895e7ab50865f5c511025d1e589ca01de7e2bd88d95e0a1a963
   languageName: node
   linkType: hard
 
@@ -12061,6 +12082,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immer@npm:^9.0.7":
+  version: 9.0.12
+  resolution: "immer@npm:9.0.12"
+  checksum: bcbec6d76dac65e49068eb67ece4d407116e62b8cde3126aa89c801e408f5047763ba0aeb62f1938c1aa704bb6612f1d8302bb2a86fa1fc60fcc12d8b25dc895
+  languageName: node
+  linkType: hard
+
 "immutable@npm:^4.0.0":
   version: 4.0.0
   resolution: "immutable@npm:4.0.0"
@@ -17618,7 +17646,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redux@npm:4.2.0":
+"redux-thunk@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "redux-thunk@npm:2.4.1"
+  peerDependencies:
+    redux: ^4
+  checksum: af5abb425fb9dccda02e5f387d6f3003997f62d906542a3d35fc9420088f550dc1a018bdc246c7d23ee852b4d4ab8b5c64c5be426e45a328d791c4586a3c6b6e
+  languageName: node
+  linkType: hard
+
+"redux@npm:4.2.0, redux@npm:^4.1.2":
   version: 4.2.0
   resolution: "redux@npm:4.2.0"
   dependencies:
@@ -17811,6 +17848,13 @@ __metadata:
   version: 1.0.0
   resolution: "requires-port@npm:1.0.0"
   checksum: eee0e303adffb69be55d1a214e415cf42b7441ae858c76dfc5353148644f6fd6e698926fc4643f510d5c126d12a705e7c8ed7e38061113bdf37547ab356797ff
+  languageName: node
+  linkType: hard
+
+"reselect@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "reselect@npm:4.1.5"
+  checksum: 54c13c1e795b2ea70cba8384138aebe78adda00cbea303cc94b64da0a70d74c896cc9a03115ae38b8bff990e7a60dcd6452ab68cbec01b0b38c1afda70714cf0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Component/Part
Redux store creationg

### Description
Since redux [4.2.0](https://github.com/hedgedoc/react-client/pull/2015) the preferred way to create a store is `configureStore` because `createStore` is deprecated. This PR changes the necessary code for store creation.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
