### PR TITLE
Extract code highlighting from async call

### DIFF
--- a/src/components/markdown-renderer/markdown-extension/highlighted-fence/highlighted-code.tsx
+++ b/src/components/markdown-renderer/markdown-extension/highlighted-fence/highlighted-code.tsx
@@ -9,9 +9,10 @@ import { CopyToClipboardButton } from '../../../common/copyable/copy-to-clipboar
 import styles from './highlighted-code.module.scss'
 import { cypressAttribute, cypressId } from '../../../../utils/cypress-attribute'
 import { AsyncLoadingBoundary } from '../../../common/async-loading-boundary'
-import { useAsyncHighlightedCodeDom } from './hooks/use-async-highlighted-code-dom'
+import { useAsyncHighlightJsImport } from './hooks/use-async-highlight-js-import'
 import { useAttachLineNumbers } from './hooks/use-attach-line-numbers'
 import { testId } from '../../../../utils/test-id'
+import { useCodeDom } from './hooks/use-code-dom'
 
 export interface HighlightedCodeProps {
   code: string
@@ -30,8 +31,9 @@ export interface HighlightedCodeProps {
  */
 export const HighlightedCode: React.FC<HighlightedCodeProps> = ({ code, language, startLineNumber, wrapLines }) => {
   const showGutter = startLineNumber !== undefined
-  const { loading, error, value: highlightedLines } = useAsyncHighlightedCodeDom(code, language)
-  const wrappedDomLines = useAttachLineNumbers(highlightedLines, startLineNumber)
+  const { value: hljsApi, loading, error } = useAsyncHighlightJsImport()
+  const codeDom = useCodeDom(code, hljsApi, language)
+  const wrappedDomLines = useAttachLineNumbers(codeDom, startLineNumber)
 
   return (
     <AsyncLoadingBoundary loading={loading} error={!!error} componentName={'highlight.js'}>

--- a/src/components/markdown-renderer/markdown-extension/highlighted-fence/hooks/use-async-highlight-js-import.tsx
+++ b/src/components/markdown-renderer/markdown-extension/highlighted-fence/hooks/use-async-highlight-js-import.tsx
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useAsync } from 'react-use'
+import { Logger } from '../../../../../utils/logger'
+import type { AsyncState } from 'react-use/lib/useAsyncFn'
+import type { HLJSApi } from 'highlight.js'
+
+const log = new Logger('HighlightedCode')
+
+/**
+ * Lazy loads the highlight js library.
+ *
+ * @return the loaded js lib
+ */
+export const useAsyncHighlightJsImport = (): AsyncState<HLJSApi> => {
+  return useAsync(async () => {
+    try {
+      return (await import(/* webpackChunkName: "highlight.js" */ '../../../../common/hljs/hljs')).default
+    } catch (error) {
+      log.error('Error while loading highlight.js', error)
+      throw error
+    }
+  }, [])
+}


### PR DESCRIPTION
### Component/Part
Highlighted Code Component

### Description
This PR extracts the actual code highlighting using hljs from the async call to prevent the waiting spinner to show up.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
