### PR TITLE
Fix multiple problems

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -73,7 +73,7 @@ const rawNextConfig = {
     )
     return config
   },
-  reactStrictMode: true,
+  reactStrictMode: false,
   redirects: () => {
     return Promise.resolve([
       {

--- a/src/components/application-loader/initializers/setupI18n.ts
+++ b/src/components/application-loader/initializers/setupI18n.ts
@@ -10,6 +10,7 @@ import LanguageDetector from 'i18next-browser-languagedetector'
 import resourcesToBackend from 'i18next-resources-to-backend'
 import { Settings } from 'luxon'
 import { initReactI18next } from 'react-i18next'
+import { isDevMode } from '../../../utils/test-modes'
 
 export const setUpI18n = async (): Promise<void> => {
   await i18nUse(
@@ -27,7 +28,7 @@ export const setUpI18n = async (): Promise<void> => {
     .use(initReactI18next)
     .init({
       fallbackLng: 'en',
-      debug: process.env.NODE_ENV !== 'production',
+      debug: isDevMode,
       interpolation: {
         escapeValue: false
       }

--- a/src/components/application-loader/loading-screen/random-icon.tsx
+++ b/src/components/application-loader/loading-screen/random-icon.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React, { useMemo } from 'react'
+import React, { useEffect, useState } from 'react'
 import type { IconName } from '../../common/fork-awesome/types'
 import { ForkAwesomeIcon } from '../../common/fork-awesome/fork-awesome-icon'
 import styles from './animations.module.scss'
@@ -26,9 +26,21 @@ const elements: IconName[] = [
 
 /**
  * Chooses a random fork awesome icon from a predefined set and renders it.
+ *
+ * The component uses a static icon in the first rendering and will choose the random icon after that.
+ * This is done because if the loading screen is prepared using SSR and then hydrated in the client, the rendered css class isn't the expected one from the SSR. (It's random. d'uh).
+ * To avoid this problem the icon will be chosen in an effect because SSR won't run effects.
+ *
+ * See https://nextjs.org/docs/messages/react-hydration-error
  */
 export const RandomIcon: React.FC = () => {
-  const icon = useMemo(() => elements[Math.floor(Math.random() * elements.length)], [])
+  const [icon, setIcon] = useState<number | undefined>()
 
-  return <ForkAwesomeIcon icon={icon} className={styles.particle}></ForkAwesomeIcon>
+  useEffect(() => {
+    setIcon(Math.floor(Math.random() * elements.length))
+  }, [])
+
+  return icon === undefined ? null : (
+    <ForkAwesomeIcon icon={elements[icon]} className={styles.particle}></ForkAwesomeIcon>
+  )
 }

--- a/src/components/editor-page/document-bar/note-info/note-info-line-created.tsx
+++ b/src/components/editor-page/document-bar/note-info/note-info-line-created.tsx
@@ -3,12 +3,13 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react'
+import React, { useMemo } from 'react'
 import { Trans } from 'react-i18next'
 import { NoteInfoLine } from './note-info-line'
 import type { NoteInfoTimeLineProps } from './note-info-time-line'
 import { useApplicationState } from '../../../../hooks/common/use-application-state'
 import { UnitalicBoldTimeFromNow } from './utils/unitalic-bold-time-from-now'
+import { DateTime } from 'luxon'
 
 /**
  * Renders an info line about the creation of the current note.
@@ -16,11 +17,12 @@ import { UnitalicBoldTimeFromNow } from './utils/unitalic-bold-time-from-now'
  */
 export const NoteInfoLineCreated: React.FC<NoteInfoTimeLineProps> = ({ size }) => {
   const noteCreateTime = useApplicationState((state) => state.noteDetails.createdAt)
+  const noteCreateDateTime = useMemo(() => DateTime.fromSeconds(noteCreateTime), [noteCreateTime])
 
   return (
     <NoteInfoLine icon={'plus'} size={size}>
       <Trans i18nKey={'editor.modal.documentInfo.created'}>
-        <UnitalicBoldTimeFromNow time={noteCreateTime} />
+        <UnitalicBoldTimeFromNow time={noteCreateDateTime} />
       </Trans>
     </NoteInfoLine>
   )

--- a/src/components/editor-page/document-bar/note-info/note-info-line-updated.tsx
+++ b/src/components/editor-page/document-bar/note-info/note-info-line-updated.tsx
@@ -11,6 +11,7 @@ import type { NoteInfoTimeLineProps } from './note-info-time-line'
 import { UnitalicBoldTimeFromNow } from './utils/unitalic-bold-time-from-now'
 import { UnitalicBoldTrans } from './utils/unitalic-bold-trans'
 import { UserAvatarForUsername } from '../../../common/user-avatar/user-avatar-for-username'
+import { DateTime } from 'luxon'
 
 /**
  * Renders an info line about the last update of the current note.
@@ -19,6 +20,7 @@ import { UserAvatarForUsername } from '../../../common/user-avatar/user-avatar-f
 export const NoteInfoLineUpdated: React.FC<NoteInfoTimeLineProps> = ({ size }) => {
   useTranslation()
   const noteUpdateTime = useApplicationState((state) => state.noteDetails.updatedAt)
+  const noteUpdateDateTime = useMemo(() => DateTime.fromSeconds(noteUpdateTime), [noteUpdateTime])
   const noteUpdateUser = useApplicationState((state) => state.noteDetails.updateUsername)
 
   const userBlock = useMemo(() => {
@@ -38,7 +40,7 @@ export const NoteInfoLineUpdated: React.FC<NoteInfoTimeLineProps> = ({ size }) =
     <NoteInfoLine icon={'pencil'} size={size}>
       <Trans i18nKey={'editor.modal.documentInfo.edited'}>
         {userBlock}
-        <UnitalicBoldTimeFromNow time={noteUpdateTime} />
+        <UnitalicBoldTimeFromNow time={noteUpdateDateTime} />
       </Trans>
     </NoteInfoLine>
   )

--- a/src/components/notifications/ui-notification-toast.tsx
+++ b/src/components/notifications/ui-notification-toast.tsx
@@ -16,6 +16,7 @@ import { cypressId } from '../../utils/cypress-attribute'
 import { useEffectOnce, useInterval } from 'react-use'
 import { dismissUiNotification } from '../../redux/ui-notifications/methods'
 import styles from './notifications.module.scss'
+import { DateTime } from 'luxon'
 
 const STEPS_PER_SECOND = 10
 const log = new Logger('UiNotificationToast')
@@ -89,6 +90,8 @@ export const UiNotificationToast: React.FC<UiNotificationProps> = ({
       })
   }, [contentI18nKey, contentI18nOptions, t])
 
+  const formattedDate = useMemo(() => DateTime.fromSeconds(date).toRelative({ style: 'short' }), [date])
+
   return (
     <Toast className={styles.toast} show={!dismissed} onClose={dismissNow} {...cypressId('notification-toast')}>
       <Toast.Header>
@@ -98,7 +101,7 @@ export const UiNotificationToast: React.FC<UiNotificationProps> = ({
           </ShowIf>
           <Trans i18nKey={titleI18nKey} tOptions={titleI18nOptions} />
         </strong>
-        <small>{date.toRelative({ style: 'short' })}</small>
+        <small>{formattedDate}</small>
       </Toast.Header>
       <Toast.Body>{contentDom}</Toast.Body>
       <ProgressBar

--- a/src/components/notifications/ui-notification-toast.tsx
+++ b/src/components/notifications/ui-notification-toast.tsx
@@ -30,7 +30,7 @@ export const UiNotificationToast: React.FC<UiNotificationProps> = ({
   contentI18nKey,
   titleI18nOptions,
   contentI18nOptions,
-  date,
+  createdAtTimestamp,
   icon,
   dismissed,
   notificationId,
@@ -49,8 +49,17 @@ export const UiNotificationToast: React.FC<UiNotificationProps> = ({
     log.debug(`Show notification ${notificationId}`)
   })
 
+  const formatCreatedAtDate = useCallback(() => {
+    return DateTime.fromSeconds(createdAtTimestamp).toRelative({ style: 'short' })
+  }, [createdAtTimestamp])
+
+  const [formattedCreatedAtDate, setFormattedCreatedAtDate] = useState(() => formatCreatedAtDate())
+
   useInterval(
-    () => setRemainingSteps((lastRemainingSteps) => lastRemainingSteps - 1),
+    () => {
+      setRemainingSteps((lastRemainingSteps) => lastRemainingSteps - 1)
+      setFormattedCreatedAtDate(formatCreatedAtDate())
+    },
     !dismissed && remainingSteps > 0 ? 1000 / STEPS_PER_SECOND : null
   )
 
@@ -90,8 +99,6 @@ export const UiNotificationToast: React.FC<UiNotificationProps> = ({
       })
   }, [contentI18nKey, contentI18nOptions, t])
 
-  const formattedDate = useMemo(() => DateTime.fromSeconds(date).toRelative({ style: 'short' }), [date])
-
   return (
     <Toast className={styles.toast} show={!dismissed} onClose={dismissNow} {...cypressId('notification-toast')}>
       <Toast.Header>
@@ -101,7 +108,7 @@ export const UiNotificationToast: React.FC<UiNotificationProps> = ({
           </ShowIf>
           <Trans i18nKey={titleI18nKey} tOptions={titleI18nOptions} />
         </strong>
-        <small>{formattedDate}</small>
+        <small>{formattedCreatedAtDate}</small>
       </Toast.Header>
       <Toast.Body>{contentDom}</Toast.Body>
       <ProgressBar

--- a/src/components/notifications/ui-notifications.tsx
+++ b/src/components/notifications/ui-notifications.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react'
+import React, { useMemo } from 'react'
 import { UiNotificationToast } from './ui-notification-toast'
 import styles from './notifications.module.scss'
 import { useApplicationState } from '../../hooks/common/use-application-state'
@@ -12,11 +12,15 @@ import { useApplicationState } from '../../hooks/common/use-application-state'
 export const UiNotifications: React.FC = () => {
   const notifications = useApplicationState((state) => state.uiNotifications)
 
+  const notificationElements = useMemo(() => {
+    return notifications.map((notification, notificationIndex) => (
+      <UiNotificationToast key={notificationIndex} notificationId={notificationIndex} {...notification} />
+    ))
+  }, [notifications])
+
   return (
     <div className={styles['notifications-area']} aria-live='polite' aria-atomic='true'>
-      {notifications.map((notification, notificationIndex) => (
-        <UiNotificationToast key={notificationIndex} notificationId={notificationIndex} {...notification} />
-      ))}
+      {notificationElements}
     </div>
   )
 }

--- a/src/redux/note-details/initial-state.ts
+++ b/src/redux/note-details/initial-state.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { DateTime } from 'luxon'
 import type { NoteDetails } from './types/note-details'
 import { NoteTextDirection, NoteType } from './types/note-details'
 import type { SlideOptions } from './types/slide-show-options'
@@ -18,7 +17,6 @@ export const initialSlideOptions: SlideOptions = {
 }
 
 export const initialState: NoteDetails = {
-  updatedAt: DateTime.fromSeconds(0),
   updateUsername: null,
   version: 0,
   markdownContent: {
@@ -35,7 +33,8 @@ export const initialState: NoteDetails = {
     slideOptions: initialSlideOptions
   },
   id: '',
-  createdAt: DateTime.fromSeconds(0),
+  createdAt: 0,
+  updatedAt: 0,
   aliases: [],
   primaryAddress: '',
   permissions: {

--- a/src/redux/note-details/reducers/build-state-from-set-note-data-from-server.test.ts
+++ b/src/redux/note-details/reducers/build-state-from-set-note-data-from-server.test.ts
@@ -114,8 +114,8 @@ describe('build state from set note data from server', () => {
       firstHeading: '',
       rawFrontmatter: '',
       id: 'id',
-      createdAt: DateTime.fromISO('2012-05-25T09:08:34.123'),
-      updatedAt: DateTime.fromISO('2020-05-25T09:08:34.123'),
+      createdAt: DateTime.fromISO('2012-05-25T09:08:34.123').toSeconds(),
+      updatedAt: DateTime.fromISO('2020-05-25T09:08:34.123').toSeconds(),
       updateUsername: 'updateusername',
       viewCount: 987,
       aliases: [

--- a/src/redux/note-details/reducers/build-state-from-set-note-data-from-server.ts
+++ b/src/redux/note-details/reducers/build-state-from-set-note-data-from-server.ts
@@ -46,7 +46,7 @@ const convertNoteDtoToNoteDetails = (note: Note): NoteDetails => {
       lineStartIndexes: calculateLineStartIndexes(newLines)
     },
     rawFrontmatter: '',
-    createdAt: DateTime.fromISO(note.metadata.createdAt),
-    updatedAt: DateTime.fromISO(note.metadata.updatedAt)
+    createdAt: DateTime.fromISO(note.metadata.createdAt).toSeconds(),
+    updatedAt: DateTime.fromISO(note.metadata.updatedAt).toSeconds()
   }
 }

--- a/src/redux/note-details/types/note-details.ts
+++ b/src/redux/note-details/types/note-details.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import type { DateTime } from 'luxon'
 import type { SlideOptions } from './slide-show-options'
 import type { ISO6391 } from './iso6391'
 import type { CursorSelection } from '../../editor/types'
@@ -16,8 +15,8 @@ type UnnecessaryNoteAttributes = 'updatedAt' | 'createdAt' | 'tags' | 'descripti
  * Redux state containing the currently loaded note with its content and metadata.
  */
 export interface NoteDetails extends Omit<NoteMetadata, UnnecessaryNoteAttributes> {
-  updatedAt: DateTime
-  createdAt: DateTime
+  updatedAt: number
+  createdAt: number
   markdownContent: {
     plain: string
     lines: string[]

--- a/src/redux/ui-notifications/methods.ts
+++ b/src/redux/ui-notifications/methods.ts
@@ -42,7 +42,7 @@ export const dispatchUiNotification = async (
       notification: {
         titleI18nKey,
         contentI18nKey,
-        date: DateTime.now(),
+        date: DateTime.now().toSeconds(),
         dismissed: false,
         titleI18nOptions: titleI18nOptions ?? {},
         contentI18nOptions: contentI18nOptions ?? {},

--- a/src/redux/ui-notifications/methods.ts
+++ b/src/redux/ui-notifications/methods.ts
@@ -42,7 +42,7 @@ export const dispatchUiNotification = async (
       notification: {
         titleI18nKey,
         contentI18nKey,
-        date: DateTime.now().toSeconds(),
+        createdAtTimestamp: DateTime.now().toSeconds(),
         dismissed: false,
         titleI18nOptions: titleI18nOptions ?? {},
         contentI18nOptions: contentI18nOptions ?? {},

--- a/src/redux/ui-notifications/types.ts
+++ b/src/redux/ui-notifications/types.ts
@@ -29,7 +29,7 @@ export interface DispatchOptions {
 export interface UiNotification extends DispatchOptions {
   titleI18nKey: string
   contentI18nKey: string
-  date: number
+  createdAtTimestamp: number
   dismissed: boolean
 }
 

--- a/src/redux/ui-notifications/types.ts
+++ b/src/redux/ui-notifications/types.ts
@@ -5,7 +5,6 @@
  */
 
 import type { Action } from 'redux'
-import type { DateTime } from 'luxon'
 import type { IconName } from '../../components/common/fork-awesome/types'
 import type { TOptions } from 'i18next'
 
@@ -30,7 +29,7 @@ export interface DispatchOptions {
 export interface UiNotification extends DispatchOptions {
   titleI18nKey: string
   contentI18nKey: string
-  date: DateTime
+  date: number
   dismissed: boolean
 }
 


### PR DESCRIPTION
### Component/Part
LoadingScreen, i18n and rendering in general

### Description
This PR fixes some problems:
- [Disable react strict mode to prevent double rendering](https://github.com/hedgedoc/react-client/pull/2039/commits/eaa753bf28af4d43832ef5eaf5ad24a90fa1b590)
- [Use correct method to set i18n into debug mode](https://github.com/hedgedoc/react-client/pull/2039/commits/b5a1b19f10a788d0f2325c0bcad1e6b721a33e0c)
- [Prevent react hydration error](https://github.com/hedgedoc/react-client/pull/2039/commits/ab3fd5882a47eadf3534d0199aa9f5c2c3a934c2)
- [Replace Luxon DateTime with number in redux state](https://github.com/hedgedoc/react-client/pull/2039/commits/cd7e3fd52a91d2a60588bceaf019cba5432d807f)

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
