### PR TITLE
Connect list of online users in sidebar to redux

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -268,7 +268,8 @@
       }
     },
     "onlineStatus": {
-      "online": "Online"
+      "online": "Online",
+      "noUsers": "No users online"
     },
     "error": {
       "locked": {

--- a/src/components/editor-page/sidebar/user-line/user-line.tsx
+++ b/src/components/editor-page/sidebar/user-line/user-line.tsx
@@ -5,10 +5,10 @@
  */
 
 import React from 'react'
-import type { ActiveIndicatorStatus } from '../users-online-sidebar-menu/active-indicator'
 import { ActiveIndicator } from '../users-online-sidebar-menu/active-indicator'
 import styles from './user-line.module.scss'
 import { UserAvatarForUsername } from '../../../common/user-avatar/user-avatar-for-username'
+import type { ActiveIndicatorStatus } from '../../../../redux/realtime/types'
 
 export interface UserLineProps {
   username: string | null

--- a/src/components/editor-page/sidebar/users-online-sidebar-menu/active-indicator.tsx
+++ b/src/components/editor-page/sidebar/users-online-sidebar-menu/active-indicator.tsx
@@ -1,16 +1,12 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
 import React from 'react'
 import styles from './active-indicator.module.scss'
-
-export enum ActiveIndicatorStatus {
-  ACTIVE = 'active',
-  INACTIVE = 'inactive'
-}
+import type { ActiveIndicatorStatus } from '../../../../redux/realtime/types'
 
 export interface ActiveIndicatorProps {
   status: ActiveIndicatorStatus

--- a/src/redux/application-state.d.ts
+++ b/src/redux/application-state.d.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -13,6 +13,7 @@ import type { NoteDetails } from './note-details/types/note-details'
 import type { UiNotificationState } from './ui-notifications/types'
 import type { RendererStatus } from './renderer-status/types'
 import type { HistoryEntryWithOrigin } from '../api/history/types'
+import type { RealtimeState } from './realtime/types'
 
 export interface ApplicationState {
   user: OptionalUserState
@@ -24,4 +25,5 @@ export interface ApplicationState {
   noteDetails: NoteDetails
   uiNotifications: UiNotificationState
   rendererStatus: RendererStatus
+  realtime: RealtimeState
 }

--- a/src/redux/realtime/methods.ts
+++ b/src/redux/realtime/methods.ts
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { store } from '..'
+import type { AddOnlineUserAction, OnlineUser, RemoveOnlineUserAction } from './types'
+import { RealtimeActionType } from './types'
+
+/**
+ * Dispatches an event to add a user
+ *
+ * @param clientId The clientId of the user to add
+ * @param user The user to add.
+ */
+export const addOnlineUser = (clientId: number, user: OnlineUser): void => {
+  const action: AddOnlineUserAction = {
+    type: RealtimeActionType.ADD_ONLINE_USER,
+    clientId,
+    user
+  }
+  store.dispatch(action)
+}
+
+/**
+ * Dispatches an event to remove a user from the online users list.
+ *
+ * @param clientId The yjs client id of the user to remove from the online users list.
+ */
+export const removeOnlineUser = (clientId: number): void => {
+  const action: RemoveOnlineUserAction = {
+    type: RealtimeActionType.REMOVE_ONLINE_USER,
+    clientId
+  }
+  store.dispatch(action)
+}

--- a/src/redux/realtime/reducers.ts
+++ b/src/redux/realtime/reducers.ts
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { RealtimeActions, RealtimeState } from './types'
+import { RealtimeActionType } from './types'
+import type { Reducer } from 'redux'
+import { buildStateFromRemoveUser } from './reducers/build-state-from-remove-user'
+import { buildStateFromAddUser } from './reducers/build-state-from-add-user'
+
+const initialState: RealtimeState = {
+  users: []
+}
+
+/**
+ * Applies {@link RealtimeReducer realtime actions} to the global application state.
+ *
+ * @param state the current state
+ * @param action the action that should get applied
+ * @return The new changed state
+ */
+export const RealtimeReducer: Reducer<RealtimeState, RealtimeActions> = (
+  state = initialState,
+  action: RealtimeActions
+) => {
+  switch (action.type) {
+    case RealtimeActionType.ADD_ONLINE_USER:
+      return buildStateFromAddUser(state, action.clientId, action.user)
+    case RealtimeActionType.REMOVE_ONLINE_USER:
+      return buildStateFromRemoveUser(state, action.clientId)
+    default:
+      return state
+  }
+}

--- a/src/redux/realtime/reducers/build-state-from-add-user.ts
+++ b/src/redux/realtime/reducers/build-state-from-add-user.ts
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { OnlineUser, RealtimeState } from '../types'
+
+/**
+ * Builds a new {@link RealtimeState} with a new client id that is shown as online.
+ *
+ * @param oldState The old state that will be copied
+ * @param clientId The identifier of the new client
+ * @param user The information about the new user
+ * @return the generated state
+ */
+export const buildStateFromAddUser = (oldState: RealtimeState, clientId: number, user: OnlineUser): RealtimeState => {
+  return {
+    users: {
+      ...oldState.users,
+      [clientId]: user
+    }
+  }
+}

--- a/src/redux/realtime/reducers/build-state-from-remove-user.ts
+++ b/src/redux/realtime/reducers/build-state-from-remove-user.ts
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { RealtimeState } from '../types'
+
+/**
+ * Builds a new {@link RealtimeState} but removes the information about a client.
+ *
+ * @param oldState The old state that will be copied
+ * @param clientIdToRemove The identifier of the client that should be removed
+ * @return the generated state
+ */
+export const buildStateFromRemoveUser = (oldState: RealtimeState, clientIdToRemove: number): RealtimeState => {
+  const newUsers = { ...oldState.users }
+  delete newUsers[clientIdToRemove]
+  return {
+    users: newUsers
+  }
+}

--- a/src/redux/realtime/types.ts
+++ b/src/redux/realtime/types.ts
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { Action } from 'redux'
+
+export enum RealtimeActionType {
+  ADD_ONLINE_USER = 'realtime/add-user',
+  REMOVE_ONLINE_USER = 'realtime/remove-user',
+  UPDATE_ONLINE_USER = 'realtime/update-user'
+}
+
+export interface RealtimeState {
+  users: Record<number, OnlineUser>
+}
+
+export enum ActiveIndicatorStatus {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive'
+}
+
+export interface OnlineUser {
+  username: string
+  color: string
+  active: ActiveIndicatorStatus
+}
+
+export interface AddOnlineUserAction extends Action<RealtimeActionType> {
+  type: RealtimeActionType.ADD_ONLINE_USER
+  clientId: number
+  user: OnlineUser
+}
+
+export interface RemoveOnlineUserAction extends Action<RealtimeActionType> {
+  type: RealtimeActionType.REMOVE_ONLINE_USER
+  clientId: number
+}
+
+export type RealtimeActions = AddOnlineUserAction | RemoveOnlineUserAction

--- a/src/redux/reducers.ts
+++ b/src/redux/reducers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -16,6 +16,7 @@ import { NoteDetailsReducer } from './note-details/reducer'
 import { UiNotificationReducer } from './ui-notifications/reducers'
 import { RendererStatusReducer } from './renderer-status/reducers'
 import type { ApplicationState } from './application-state'
+import { RealtimeReducer } from './realtime/reducers'
 
 export const allReducers: Reducer<ApplicationState> = combineReducers<ApplicationState>({
   user: UserReducer,
@@ -26,5 +27,6 @@ export const allReducers: Reducer<ApplicationState> = combineReducers<Applicatio
   darkMode: DarkModeConfigReducer,
   noteDetails: NoteDetailsReducer,
   uiNotifications: UiNotificationReducer,
-  rendererStatus: RendererStatusReducer
+  rendererStatus: RendererStatusReducer,
+  realtime: RealtimeReducer
 })


### PR DESCRIPTION
### Component/Part
Sidebar menu for online users

### Description
This PR connects the list of online users to the redux store instead of a mock list.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
