### PR TITLE
Add renovate group for codemirror

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -78,6 +78,13 @@
       "matchPackagePatterns": [
         "^@testing-library/"
       ]
+    },
+    {
+      "groupName": "CodeMirror",
+      "matchPackagePatterns": [
+        "^@codemirror/",
+        "@uiw/react-codemirror"
+      ]
     }
   ],
   "prHourlyLimit": 0,


### PR DESCRIPTION
### Component/Part
Renovate

### Description
This PR adds a new group for all codemirror dependencies.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
