### PR TITLE
fix(notification): set position of notification-area to fixed

### DIFF
--- a/src/components/notifications/notifications.module.scss
+++ b/src/components/notifications/notifications.module.scss
@@ -1,11 +1,11 @@
-/*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+/*!
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
 .notifications-area {
-  position: absolute;
+  position: fixed;
   top: 15px;
   right: 15px;
   z-index: 2000;


### PR DESCRIPTION
### Component/Part
notifications

### Description
This PR fixes the position of notification-area to fixed.

This prevents notification to stick to the top of the page not able to be seen by users scrolled down the page.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
fixes #1956
