### PR TITLE
Add eslint-plugin-prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
     ]
   },
   "rules": {
+    "prettier/prettier": "error",
     "no-use-before-define": "off",
     "no-debugger": "warn",
     "default-param-last": "off",
@@ -30,7 +31,8 @@
   "plugins": [
     "@typescript-eslint",
     "testing-library",
-    "jest"
+    "jest",
+    "prettier"
   ],
   "extends": [
     "next/core-web-vitals",

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,35 +35,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+
       - name: Install dependencies
         run: yarn install --immutable
+
       - name: Lint code
         run: yarn lint
-  format:
-    runs-on: ubuntu-latest
-    name: Checks codestyle of all .ts and .tsx files
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-      - name: Cache yarn cache
-        uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-18-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-18
-
-      - name: Set up NodeJS
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-      - name: Install dependencies
-        run: yarn install --immutable
-      - name: Lint code
-        run: yarn format

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "eslint-plugin-cypress": "2.12.1",
     "eslint-plugin-jest": "26.5.3",
     "eslint-plugin-node": "11.1.0",
+    "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-promise": "6.0.0",
     "eslint-plugin-testing-library": "5.5.1",
     "jest": "28.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2033,6 +2033,7 @@ __metadata:
     eslint-plugin-cypress: 2.12.1
     eslint-plugin-jest: 26.5.3
     eslint-plugin-node: 11.1.0
+    eslint-plugin-prettier: 4.2.1
     eslint-plugin-promise: 6.0.0
     eslint-plugin-testing-library: 5.5.1
     fast-deep-equal: 3.1.3
@@ -9979,6 +9980,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-prettier@npm:4.2.1":
+  version: 4.2.1
+  resolution: "eslint-plugin-prettier@npm:4.2.1"
+  dependencies:
+    prettier-linter-helpers: ^1.0.0
+  peerDependencies:
+    eslint: ">=7.28.0"
+    prettier: ">=2.0.0"
+  peerDependenciesMeta:
+    eslint-config-prettier:
+      optional: true
+  checksum: b9e839d2334ad8ec7a5589c5cb0f219bded260839a857d7a486997f9870e95106aa59b8756ff3f37202085ebab658de382b0267cae44c3a7f0eb0bcc03a4f6d6
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-promise@npm:6.0.0":
   version: 6.0.0
   resolution: "eslint-plugin-promise@npm:6.0.0"
@@ -10500,7 +10516,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-diff@npm:^1.2.0":
+"fast-diff@npm:^1.1.2, fast-diff@npm:^1.2.0":
   version: 1.2.0
   resolution: "fast-diff@npm:1.2.0"
   checksum: 1b5306eaa9e826564d9e5ffcd6ebd881eb5f770b3f977fcbf38f05c824e42172b53c79920e8429c54eb742ce15a0caf268b0fdd5b38f6de52234c4a8368131ae
@@ -16755,6 +16771,15 @@ __metadata:
   version: 2.0.0
   resolution: "prepend-http@npm:2.0.0"
   checksum: 7694a9525405447662c1ffd352fcb41b6410c705b739b6f4e3a3e21cf5fdede8377890088e8934436b8b17ba55365a615f153960f30877bf0d0392f9e93503ea
+  languageName: node
+  linkType: hard
+
+"prettier-linter-helpers@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "prettier-linter-helpers@npm:1.0.0"
+  dependencies:
+    fast-diff: ^1.1.2
+  checksum: 00ce8011cf6430158d27f9c92cfea0a7699405633f7f1d4a45f07e21bf78e99895911cbcdc3853db3a824201a7c745bd49bfea8abd5fb9883e765a90f74f8392
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Component/Part
Code linting

### Description
This PR adds the eslint-prettier-plugin that integrates the prettier code format checks into eslint.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
