### PR TITLE
Add mutation observer to first heading title extraction logic

### DIFF
--- a/cypress/e2e/documentTitle.spec.ts
+++ b/cypress/e2e/documentTitle.spec.ts
@@ -76,8 +76,6 @@ describe('Document Title', () => {
     it('katex code looks right', () => {
       cy.setCodemirrorContent(`# $\\alpha$-foo`)
       cy.getIframeBody().find('h1').should('contain', 'α')
-      //TODO: Remove workaround after https://github.com/hedgedoc/react-client/issues/1816 has been fixed.
-      cy.get('.cm-editor .cm-content').type('{Enter}{Enter}{Enter}{Enter}{Enter}')
       cy.title().should('eq', `α-foo - HedgeDoc @ ${branding.name}`)
     })
   })


### PR DESCRIPTION
### Component/Part
First heading title extraction

### Description
This PR adds an [Mutation Observer](https://developer.mozilla.org/de/docs/Web/API/MutationObserver) to the found first headline element to detect async changes that have been made outside of the react rendering to the DOM-Elements.

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
Fixes #1816 
