### PR TITLE
Use window location as base url for websocket url construction

### DIFF
--- a/src/components/editor-page/editor-pane/hooks/yjs/use-websocket-url.ts
+++ b/src/components/editor-page/editor-pane/hooks/yjs/use-websocket-url.ts
@@ -22,7 +22,7 @@ export const useWebsocketUrl = (): URL => {
       return process.env.NEXT_PUBLIC_REALTIME_URL ?? LOCAL_FALLBACK_URL
     }
     try {
-      const backendBaseUrlParsed = new URL(backendUrl)
+      const backendBaseUrlParsed = new URL(backendUrl, window.location.toString())
       backendBaseUrlParsed.protocol = backendBaseUrlParsed.protocol === 'https:' ? 'wss:' : 'ws:'
       backendBaseUrlParsed.pathname += 'realtime'
       return backendBaseUrlParsed.toString()


### PR DESCRIPTION
### Component/Part
Websocket URL generation

### Description
This PR fixes a crash that happens when the websocket URL can't be generated because the provided URL to the backend is relative. 

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
