### PR TITLE
Remove redux devtools package

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,6 @@
     "netlify-cli": "10.7.1",
     "prettier": "2.7.1",
     "react-test-renderer": "18.2.0",
-    "redux-devtools-extension": "2.13.9",
     "ts-loader": "9.3.1",
     "ts-mockery": "1.2.0",
     "ts-node": "10.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2087,7 +2087,6 @@ __metadata:
     react-test-renderer: 18.2.0
     react-use: 17.4.0
     redux: 4.2.0
-    redux-devtools-extension: 2.13.9
     reveal.js: 4.3.1
     sanitize-filename: 1.6.3
     sass: 1.53.0
@@ -17237,15 +17236,6 @@ __metadata:
     indent-string: ^4.0.0
     strip-indent: ^3.0.0
   checksum: fa1ef20404a2d399235e83cc80bd55a956642e37dd197b4b612ba7327bf87fa32745aeb4a1634b2bab25467164ab4ed9c15be2c307923dd08b0fe7c52431ae6b
-  languageName: node
-  linkType: hard
-
-"redux-devtools-extension@npm:2.13.9":
-  version: 2.13.9
-  resolution: "redux-devtools-extension@npm:2.13.9"
-  peerDependencies:
-    redux: ^3.1.0 || ^4.0.0
-  checksum: 603d48fd6acf3922ef373b251ab3fdbb990035e90284191047b29d25b06ea18122bc4ef01e0704ccae495acb27ab5e47b560937e98213605dd88299470025db9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Component/Part
Packages

### Description
The package "redux-devtools-extension" is deprecated. It also seems like it isn't necessary anymore since redux toolkit (https://redux-toolkit.js.org/usage/usage-guide#store-setup).

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
