### PR TITLE
Remove non-existing css class reference in splitter

### DIFF
--- a/src/components/editor-page/splitter/__snapshots__/splitter.test.tsx.snap
+++ b/src/components/editor-page/splitter/__snapshots__/splitter.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Splitter can render both panes 1`] = `
       />
     </div>
     <div
-      class="splitter right "
+      class="splitter"
       style="width: calc(100% - 50%);"
     >
       right
@@ -41,7 +41,7 @@ exports[`Splitter can render only the left pane 1`] = `
       left
     </div>
     <div
-      class="splitter right d-none"
+      class="splitter d-none"
       style="width: calc(100% - 100%);"
     >
       right
@@ -62,7 +62,7 @@ exports[`Splitter can render only the right pane 1`] = `
       left
     </div>
     <div
-      class="splitter right "
+      class="splitter"
       style="width: calc(100% - 0%);"
     >
       right
@@ -91,7 +91,7 @@ exports[`Splitter resize can change size with mouse 1`] = `
       />
     </div>
     <div
-      class="splitter right "
+      class="splitter"
       style="width: calc(100% - 50%);"
     >
       right
@@ -120,7 +120,7 @@ exports[`Splitter resize can change size with mouse 2`] = `
       />
     </div>
     <div
-      class="splitter right "
+      class="splitter"
       style="width: calc(100% - 100%);"
     >
       right
@@ -149,7 +149,7 @@ exports[`Splitter resize can change size with mouse 3`] = `
       />
     </div>
     <div
-      class="splitter right "
+      class="splitter"
       style="width: calc(100% - 0%);"
     >
       right
@@ -178,7 +178,7 @@ exports[`Splitter resize can change size with mouse 4`] = `
       />
     </div>
     <div
-      class="splitter right "
+      class="splitter"
       style="width: calc(100% - 0%);"
     >
       right
@@ -207,7 +207,7 @@ exports[`Splitter resize can change size with touch 1`] = `
       />
     </div>
     <div
-      class="splitter right "
+      class="splitter"
       style="width: calc(100% - 50%);"
     >
       right
@@ -236,7 +236,7 @@ exports[`Splitter resize can change size with touch 2`] = `
       />
     </div>
     <div
-      class="splitter right "
+      class="splitter"
       style="width: calc(100% - 100%);"
     >
       right
@@ -265,7 +265,7 @@ exports[`Splitter resize can change size with touch 3`] = `
       />
     </div>
     <div
-      class="splitter right "
+      class="splitter"
       style="width: calc(100% - 0%);"
     >
       right
@@ -294,7 +294,7 @@ exports[`Splitter resize can change size with touch 4`] = `
       />
     </div>
     <div
-      class="splitter right "
+      class="splitter"
       style="width: calc(100% - 0%);"
     >
       right

--- a/src/components/editor-page/splitter/splitter.tsx
+++ b/src/components/editor-page/splitter/splitter.tsx
@@ -126,7 +126,7 @@ export const Splitter: React.FC<SplitterProps> = ({
         </div>
       </ShowIf>
       <div
-        className={`${styles['splitter']} ${styles['right']} ${!showRight ? 'd-none' : ''}`}
+        className={`${styles['splitter']}${!showRight ? ' d-none' : ''}`}
         style={{ width: `calc(100% - ${adjustedRelativeSplitValue}%)` }}>
         {right}
       </div>


### PR DESCRIPTION
### Component/Part
Splitter

### Description
The splitter referenced an old css class '.splitter > .right' that doesn't exist anymore.
The HTML dom therefore rendered the right side of the splitter with an class name of 'undefined'.
This PR removes the invalid reference.

See https://github.com/hedgedoc/react-client/blob/main/src/components/editor-page/splitter/splitter.module.scss

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
none
