### PR TITLE
Update cypress browser image to node16.14.2-slim-chrome103-ff102

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # renovate: datasource=docker depName=cypress/browsers versioning=docker
-      image: cypress/browsers:node16.13.2-chrome100-ff98
+      image: cypress/browsers:node16.14.2-slim-chrome103-ff102
       options: --user 1001 --shm-size=2g
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Component/Part
CI E2E Test Workflow

### Description
This PR updates the version of the used cypress browser image.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
