### PR TITLE
Fixes warnings in some tests

### DIFF
--- a/src/components/common/copyable/copy-to-clipboard-button/copy-to-clipboard-button.test.tsx
+++ b/src/components/common/copyable/copy-to-clipboard-button/copy-to-clipboard-button.test.tsx
@@ -4,15 +4,9 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-/*
- * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
- *
- * SPDX-License-Identifier: AGPL-3.0-only
- */
-
 import { mockI18n } from '../../../markdown-renderer/test-utils/mock-i18n'
 import { CopyToClipboardButton } from './copy-to-clipboard-button'
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import * as uuidModule from 'uuid'
 
 jest.mock('uuid')
@@ -46,7 +40,9 @@ describe('Copy to clipboard button', () => {
     const view = render(copyToClipboardButton)
     expect(view.container).toMatchSnapshot()
     const button = await screen.findByTitle('renderer.highlightCode.copyCode')
-    button.click()
+    act(() => {
+      button.click()
+    })
     const tooltip = await screen.findByRole('tooltip')
     expect(tooltip).toHaveTextContent(expectSuccess ? 'copyOverlay.success' : 'copyOverlay.error')
     expect(tooltip).toHaveAttribute('id', overlayId)

--- a/src/components/common/note-loading-boundary/__snapshots__/create-non-existing-note-hint.test.tsx.snap
+++ b/src/components/common/note-loading-boundary/__snapshots__/create-non-existing-note-hint.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`create non existing note hint renders an button as initial state 1`] = 
 <div>
   <div
     class="fade mt-5 alert alert-info show"
-    data-testid="failedMessage"
+    data-testid="createNoteMessage"
     role="alert"
   >
     <span>
@@ -59,14 +59,14 @@ exports[`create non existing note hint renders an button as initial state 1`] = 
 exports[`create non existing note hint shows an error message if note couldn't be created 1`] = `
 <div>
   <div
-    class="fade mt-5 alert alert-info show"
-    data-testid="loadingMessage"
+    class="fade mt-5 alert alert-danger show"
+    data-testid="failedMessage"
     role="alert"
   >
     <i
-      class="fa  fa-spinner fa-spin mr-2 "
+      class="fa  fa-exclamation-triangle mr-1 "
     />
-    noteLoadingBoundary.createNote.creating
+    noteLoadingBoundary.createNote.error
   </div>
 </div>
 `;

--- a/src/components/common/note-loading-boundary/create-non-existing-note-hint.tsx
+++ b/src/components/common/note-loading-boundary/create-non-existing-note-hint.tsx
@@ -54,7 +54,7 @@ export const CreateNonExistingNoteHint: React.FC = () => {
     )
   } else {
     return (
-      <Alert variant={'info'} {...testId('failedMessage')} className={'mt-5'}>
+      <Alert variant={'info'} {...testId('createNoteMessage')} className={'mt-5'}>
         <span>
           <Trans i18nKey={'noteLoadingBoundary.createNote.question'} values={{ aliasName: noteIdFromUrl }} />
         </span>

--- a/src/components/common/user-avatar/user-avatar.test.tsx
+++ b/src/components/common/user-avatar/user-avatar.test.tsx
@@ -7,6 +7,7 @@
 import { UserAvatar } from './user-avatar'
 import { render } from '@testing-library/react'
 import type { UserInfo } from '../../../api/users/types'
+import { mockI18n } from '../../markdown-renderer/test-utils/mock-i18n'
 
 describe('UserAvatar', () => {
   const user: UserInfo = {
@@ -14,6 +15,11 @@ describe('UserAvatar', () => {
     displayName: 'Boaty McBoatFace',
     photo: 'https://example.com/test.png'
   }
+
+  beforeEach(async () => {
+    await mockI18n()
+  })
+
   it('renders the user avatar correctly', () => {
     const view = render(<UserAvatar user={user} />)
     expect(view.container).toMatchSnapshot()

--- a/src/utils/wait-for-other-promises-to-finish.ts
+++ b/src/utils/wait-for-other-promises-to-finish.ts
@@ -6,7 +6,12 @@
 
 /**
  * Waits until all other pending promises are processed.
+ *
+ * NodeJS has a queue for async code that waits for being processed. This method adds a promise to the very end of this queue.
+ * If the promise is resolved then this means that all other promises before it have been processed as well.
+ *
+ * @return A promise which resolves when all other promises have been processed
  */
-export async function waitForOtherPromisesToFinish(): Promise<void> {
-  return await new Promise((resolve) => process.nextTick(resolve))
+export function waitForOtherPromisesToFinish(): Promise<void> {
+  return new Promise((resolve) => process.nextTick(resolve))
 }

--- a/src/utils/wait-for-other-promises-to-finish.ts
+++ b/src/utils/wait-for-other-promises-to-finish.ts
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/**
+ * Waits until all other pending promises are processed.
+ */
+export async function waitForOtherPromisesToFinish(): Promise<void> {
+  return await new Promise((resolve) => process.nextTick(resolve))
+}


### PR DESCRIPTION
### Component/Part
Component tests

### Description
This PR fixes some warnings in
- `copy-to-clipboard-button.test.tsx`
- `create-non-existing-note.test.tsx`
- `user-avatar.test.tsx`

### Steps

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
