### PR TITLE
Fix size of highlighting if frontmatter is invalid

### DIFF
--- a/src/components/editor-page/editor-pane/linter/frontmatter-linter.spec.ts
+++ b/src/components/editor-page/editor-pane/linter/frontmatter-linter.spec.ts
@@ -45,8 +45,8 @@ describe('FrontmatterLinter', () => {
       testFrontmatterLinter(
         '---\ntags: a\n---',
         {
-          from: 4,
-          to: 11,
+          from: 5,
+          to: 12,
           severity: 'warning'
         },
         'tags:\n- a'
@@ -56,8 +56,8 @@ describe('FrontmatterLinter', () => {
       testFrontmatterLinter(
         '---\ntags: 1\n---',
         {
-          from: 4,
-          to: 11,
+          from: 5,
+          to: 12,
           severity: 'warning'
         },
         'tags:\n- 1'
@@ -67,8 +67,8 @@ describe('FrontmatterLinter', () => {
       testFrontmatterLinter(
         '---\ntags: 123, a\n---',
         {
-          from: 4,
-          to: 16,
+          from: 5,
+          to: 17,
           severity: 'warning'
         },
         'tags:\n- 123\n- a'
@@ -77,8 +77,8 @@ describe('FrontmatterLinter', () => {
   })
   it('with invalid yaml', () => {
     testFrontmatterLinter('---\n1\n  2: 3\n---', {
-      from: 0,
-      to: 16,
+      from: 4,
+      to: 12,
       severity: 'error'
     })
   })

--- a/src/components/editor-page/editor-pane/linter/frontmatter-linter.ts
+++ b/src/components/editor-page/editor-pane/linter/frontmatter-linter.ts
@@ -23,13 +23,14 @@ export class FrontmatterLinter implements Linter {
     if (!frontmatterExtraction.isPresent) {
       return []
     }
-    const frontmatterLines = lines.slice(0, frontmatterExtraction.lineOffset + 1)
+    const startOfYaml = lines[0].length + 1
+    const frontmatterLines = lines.slice(1, frontmatterExtraction.lineOffset - 1)
     const rawNoteFrontmatter = FrontmatterLinter.loadYaml(frontmatterExtraction.rawText)
     if (rawNoteFrontmatter === undefined) {
       return [
         {
-          from: 0,
-          to: frontmatterLines.join('\n').length,
+          from: startOfYaml,
+          to: startOfYaml + frontmatterLines.join('\n').length,
           message: t('editor.linter.frontmatter'),
           severity: 'error'
         }
@@ -46,7 +47,7 @@ export class FrontmatterLinter implements Linter {
     const replacedText = 'tags:\n- ' + tags.join('\n- ')
     const tagsLineIndex = frontmatterLines.findIndex((value) => value.startsWith('tags: '))
     const linesBeforeTagsLine = frontmatterLines.slice(0, tagsLineIndex)
-    const from = linesBeforeTagsLine.join('\n').length + 1
+    const from = startOfYaml + linesBeforeTagsLine.join('\n').length + 1
     const to = from + frontmatterLines[tagsLineIndex].length
     return [
       {


### PR DESCRIPTION
### Component/Part
Frontmatter linter

### Description
This PR fixes the size of the highlighted part if the frontmatter is invalid.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Before
![image](https://user-images.githubusercontent.com/6124140/182197608-0264e64f-7520-4634-9991-dce4ff2dca48.png)

### After
![image](https://user-images.githubusercontent.com/6124140/182197575-8c0c8ee7-f11b-4b88-880b-2a0d8f427220.png)
