### PR TITLE
feat: configure linkify in markdownit with tlds

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "sanitize-filename": "1.6.3",
     "sass": "1.54.5",
     "sharp": "0.30.7",
+    "tlds": "1.231.0",
     "twemoji-colr-font": "14.0.2",
     "uuid": "8.3.2",
     "vega": "5.22.1",

--- a/src/components/markdown-renderer/markdown-extension/__snapshots__/linkify-fix-markdown-extension.test.tsx.snap
+++ b/src/components/markdown-renderer/markdown-extension/__snapshots__/linkify-fix-markdown-extension.test.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Linkify markdown extensions renders a .rocks link correctly 1`] = `
+<div>
+  <p>
+    <a
+      href="http://example.rocks"
+    >
+      example.rocks
+    </a>
+  </p>
+  
+
+  <p>
+    <a
+      href="http://example.com"
+    >
+      example.com
+    </a>
+  </p>
+  
+
+  <p>
+    <a
+      href="http://example.de"
+    >
+      example.de
+    </a>
+  </p>
+  
+
+</div>
+`;

--- a/src/components/markdown-renderer/markdown-extension/linkify-fix-markdown-extension.test.tsx
+++ b/src/components/markdown-renderer/markdown-extension/linkify-fix-markdown-extension.test.tsx
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { mockI18n } from '../test-utils/mock-i18n'
+import { render } from '@testing-library/react'
+import { TestMarkdownRenderer } from '../test-utils/test-markdown-renderer'
+import { LinkifyFixMarkdownExtension } from './linkify-fix-markdown-extension'
+
+describe('Linkify markdown extensions', () => {
+  beforeAll(async () => {
+    await mockI18n()
+  })
+
+  it('renders a .rocks link correctly', () => {
+    const view = render(
+      <TestMarkdownRenderer
+        extensions={[new LinkifyFixMarkdownExtension()]}
+        content={'example.rocks\n\nexample.com\n\nexample.de'}
+      />
+    )
+    expect(view.container).toMatchSnapshot()
+  })
+})

--- a/src/components/markdown-renderer/markdown-extension/linkify-fix-markdown-extension.ts
+++ b/src/components/markdown-renderer/markdown-extension/linkify-fix-markdown-extension.ts
@@ -7,12 +7,14 @@
 import { MarkdownExtension } from './markdown-extension'
 import linkify from 'markdown-it/lib/rules_core/linkify'
 import type MarkdownIt from 'markdown-it'
+import tlds from 'tlds'
 
 /**
  * A markdown extension that detects plain text URLs and converts them into links.
  */
 export class LinkifyFixMarkdownExtension extends MarkdownExtension {
   public configureMarkdownItPost(markdownIt: MarkdownIt): void {
+    markdownIt.linkify.tlds(tlds)
     markdownIt.core.ruler.push('linkify', (state) => {
       try {
         state.md.options.linkify = true

--- a/yarn.lock
+++ b/yarn.lock
@@ -2048,6 +2048,7 @@ __metadata:
     sanitize-filename: 1.6.3
     sass: 1.54.5
     sharp: 0.30.7
+    tlds: 1.231.0
     ts-loader: 9.3.1
     ts-mockery: 1.2.0
     ts-node: 10.9.1
@@ -12577,6 +12578,15 @@ __metadata:
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: a38c3e059853c494af95d50c072b83f8b676a9ba2818dcc5b108ef252230735c54e0185437618596c790bbba8fcdaef5b290405981ffa09dce67b1f1bf190cbd
+  languageName: node
+  linkType: hard
+
+"tlds@npm:1.231.0":
+  version: 1.231.0
+  resolution: "tlds@npm:1.231.0"
+  bin:
+    tlds: bin.js
+  checksum: a77078c8d329c8a1f91d58459f48174a4d2be2cea1e48b8d732a3122dd394b23c5c18187882ad0139d01076191167242afa2307ec3f63c0ae9dcea0c9e9b48cc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Component/Part
renderer

### Description
This PR fixes the autodetection of linkify.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
closes #2304 