### PR TITLE
fix: Use more strict youtube id regex

### DIFF
--- a/src/components/markdown-renderer/markdown-extension/gist/replace-legacy-gist-short-code.ts
+++ b/src/components/markdown-renderer/markdown-extension/gist/replace-legacy-gist-short-code.ts
@@ -7,7 +7,7 @@
 import type { RegexOptions } from '../../../../external-types/markdown-it-regex/interface'
 import { GistMarkdownExtension } from './gist-markdown-extension'
 
-const finalRegex = /^{%gist (\w+\/\w+) ?%}$/
+const finalRegex = /^{%gist\s+(\w+\/\w+)\s*%}$/
 
 /**
  * Replacer for legacy hedgedoc 1 gist shortcodes.

--- a/src/components/markdown-renderer/markdown-extension/legacy-short-codes/replace-legacy-pdf-short-code.ts
+++ b/src/components/markdown-renderer/markdown-extension/legacy-short-codes/replace-legacy-pdf-short-code.ts
@@ -8,7 +8,7 @@ import markdownItRegex from 'markdown-it-regex'
 import type MarkdownIt from 'markdown-it/lib'
 import type { RegexOptions } from '../../../../external-types/markdown-it-regex/interface'
 
-export const legacyPdfRegex = /^{%pdf (\S*) *%}$/
+export const legacyPdfRegex = /^{%pdf\s+(\S*)\s*%}$/
 
 /**
  * Configure the given {@link MarkdownIt} to render legacy hedgedoc 1 pdf shortcodes as html links.

--- a/src/components/markdown-renderer/markdown-extension/legacy-short-codes/replace-legacy-slideshare-short-code.ts
+++ b/src/components/markdown-renderer/markdown-extension/legacy-short-codes/replace-legacy-slideshare-short-code.ts
@@ -8,7 +8,7 @@ import markdownItRegex from 'markdown-it-regex'
 import type MarkdownIt from 'markdown-it/lib'
 import type { RegexOptions } from '../../../../external-types/markdown-it-regex/interface'
 
-export const legacySlideshareRegex = /^{%slideshare (\w+\/[\w-]+) ?%}$/
+export const legacySlideshareRegex = /^{%slideshare\s+(\w+\/[\w-]+)\s*%}$/
 
 /**
  * Configure the given {@link MarkdownIt} to render legacy hedgedoc 1 slideshare shortcodes as HTML links.

--- a/src/components/markdown-renderer/markdown-extension/legacy-short-codes/replace-legacy-speakerdeck-short-code.ts
+++ b/src/components/markdown-renderer/markdown-extension/legacy-short-codes/replace-legacy-speakerdeck-short-code.ts
@@ -8,7 +8,7 @@ import markdownItRegex from 'markdown-it-regex'
 import type MarkdownIt from 'markdown-it/lib'
 import type { RegexOptions } from '../../../../external-types/markdown-it-regex/interface'
 
-export const legacySpeakerdeckRegex = /^{%speakerdeck (\w+\/[\w-]+) ?%}$/
+export const legacySpeakerdeckRegex = /^{%speakerdeck\s+(\w+\/[\w-]+)\s*%}$/
 
 /**
  * Configure the given {@link MarkdownIt} to render legacy hedgedoc 1 speakerdeck shortcodes as HTML links.

--- a/src/components/markdown-renderer/markdown-extension/vimeo/replace-legacy-vimeo-short-code.ts
+++ b/src/components/markdown-renderer/markdown-extension/vimeo/replace-legacy-vimeo-short-code.ts
@@ -9,7 +9,7 @@ import { VimeoMarkdownExtension } from './vimeo-markdown-extension'
 import type MarkdownIt from 'markdown-it'
 import markdownItRegex from 'markdown-it-regex'
 
-export const legacyVimeoRegex = /^{%vimeo ([\d]{6,11}) ?%}$/
+export const legacyVimeoRegex = /^{%vimeo\s+(\d{6,11})\s*%}$/
 
 /**
  * Configure the given {@link MarkdownIt} to render legacy hedgedoc 1 vimeo short codes as embeddings.

--- a/src/components/markdown-renderer/markdown-extension/vimeo/replace-vimeo-link.ts
+++ b/src/components/markdown-renderer/markdown-extension/vimeo/replace-vimeo-link.ts
@@ -11,7 +11,7 @@ import markdownItRegex from 'markdown-it-regex'
 
 const protocolRegex = /(?:http(?:s)?:\/\/)?/
 const domainRegex = /(?:player\.)?(?:vimeo\.com\/)(?:(?:channels|album|ondemand|groups)\/\w+\/)?(?:video\/)?/
-const idRegex = /([\d]{6,11})/
+const idRegex = /(\d{6,11})/
 const tailRegex = /(?:[?#].*)?/
 const vimeoVideoUrlRegex = new RegExp(
   `(?:${protocolRegex.source}${domainRegex.source}${idRegex.source}${tailRegex.source})`

--- a/src/components/markdown-renderer/markdown-extension/youtube/replace-legacy-youtube-short-code.test.ts
+++ b/src/components/markdown-renderer/markdown-extension/youtube/replace-legacy-youtube-short-code.test.ts
@@ -29,12 +29,17 @@ describe('Replace legacy youtube short codes', () => {
     expect(markdownIt.renderInline(code)).toBe(code)
   })
 
-  it("won't detect an invalid(to short) youtube id", () => {
+  it("won't detect an invalid(too short) youtube id", () => {
     const code = '{%youtube 1 %}'
     expect(markdownIt.renderInline(code)).toBe(code)
   })
 
-  it("won't detect an invalid(to long) youtube id", () => {
+  it("won't detect an invalid(invalid characters) youtube id", () => {
+    const code = '{%youtube /!#/ %}'
+    expect(markdownIt.renderInline(code)).toBe(code)
+  })
+
+  it("won't detect an invalid(too long) youtube id", () => {
     const code = '{%youtube 111111111111111111111111111111111 %}'
     expect(markdownIt.renderInline(code)).toBe(code)
   })

--- a/src/components/markdown-renderer/markdown-extension/youtube/replace-legacy-youtube-short-code.ts
+++ b/src/components/markdown-renderer/markdown-extension/youtube/replace-legacy-youtube-short-code.ts
@@ -9,7 +9,7 @@ import { YoutubeMarkdownExtension } from './youtube-markdown-extension'
 import markdownItRegex from 'markdown-it-regex'
 import type MarkdownIt from 'markdown-it'
 
-export const legacyYouTubeRegex = /^{%youtube ([^"&?\\/\s]{11}) ?%}$/
+export const legacyYouTubeRegex = /^{%youtube\s+([\w-]{11})\s*%}$/
 
 /**
  * Configure the given {@link MarkdownIt} to render legacy hedgedoc 1 youtube short codes as embeddings.

--- a/src/components/markdown-renderer/markdown-extension/youtube/replace-youtube-link.test.ts
+++ b/src/components/markdown-renderer/markdown-extension/youtube/replace-youtube-link.test.ts
@@ -32,6 +32,21 @@ describe('Replace youtube link', () => {
           it("won't detect an URL without video id", () => {
             expect(markdownIt.renderInline(origin)).toBe(origin)
           })
+
+          it("won't detect an invalid(too short) youtube id", () => {
+            const invalidUrl = '${origin}?v=1'
+            expect(markdownIt.renderInline(invalidUrl)).toBe(invalidUrl)
+          })
+
+          it("won't detect an invalid(invalid characters) youtube id", () => {
+            const invalidUrl = '${origin}?v= /!#/'
+            expect(markdownIt.renderInline(invalidUrl)).toBe(invalidUrl)
+          })
+
+          it("won't detect an invalid(too long) youtube id", () => {
+            const invalidUrl = '${origin}?v=111111111111111111111111111111111'
+            expect(markdownIt.renderInline(invalidUrl)).toBe(invalidUrl)
+          })
         })
       })
     })

--- a/src/components/markdown-renderer/markdown-extension/youtube/replace-youtube-link.ts
+++ b/src/components/markdown-renderer/markdown-extension/youtube/replace-youtube-link.ts
@@ -12,7 +12,7 @@ import type MarkdownIt from 'markdown-it'
 const protocolRegex = /(?:http(?:s)?:\/\/)?/
 const subdomainRegex = /(?:www.)?/
 const pathRegex = /(?:youtube(?:-nocookie)?\.com\/(?:[^\\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)/
-const idRegex = /([^"&?\\/\s]{11})/
+const idRegex = /([\w-]{11})/
 const tailRegex = /(?:[?&#].*)?/
 const youtubeVideoUrlRegex = new RegExp(
   `(?:${protocolRegex.source}${subdomainRegex.source}${pathRegex.source}${idRegex.source}${tailRegex.source})`


### PR DESCRIPTION
### Component/Part
Youtube embedding

### Description
This PR improves the yt id regex by making it more strict.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
