### PR TITLE
fix(websocket): error when leaving realtime-note

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@hedgedoc/html-to-react": "1.4.5",
     "@hedgedoc/markdown-it-image-size": "1.0.3",
     "@hedgedoc/markdown-it-task-lists": "1.0.5",
-    "@hedgedoc/realtime": "0.1.1",
+    "@hedgedoc/realtime": "0.2.0",
     "@hpcc-js/wasm": "1.12.8",
     "@matejmazur/react-katex": "3.1.3",
     "@mrdrogdrog/optional": "0.2.0",

--- a/src/components/editor-page/editor-pane/hooks/yjs/websocket-connection.ts
+++ b/src/components/editor-page/editor-pane/hooks/yjs/websocket-connection.ts
@@ -51,7 +51,7 @@ export class WebsocketConnection extends WebsocketTransporter {
   private bindYDocEvents(doc: Doc): void {
     doc.on('destroy', () => this.disconnect())
     doc.on('update', (update: Uint8Array, origin: unknown) => {
-      if (origin !== this && this.isSynced()) {
+      if (origin !== this && this.isSynced() && this.isWebSocketOpen()) {
         this.send(encodeDocumentUpdateMessage(update))
       }
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1925,7 +1925,7 @@ __metadata:
     "@hedgedoc/html-to-react": 1.4.5
     "@hedgedoc/markdown-it-image-size": 1.0.3
     "@hedgedoc/markdown-it-task-lists": 1.0.5
-    "@hedgedoc/realtime": 0.1.1
+    "@hedgedoc/realtime": 0.2.0
     "@hpcc-js/wasm": 1.12.8
     "@matejmazur/react-katex": 3.1.3
     "@mrdrogdrog/optional": 0.2.0
@@ -2054,16 +2054,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hedgedoc/realtime@npm:0.1.1":
-  version: 0.1.1
-  resolution: "@hedgedoc/realtime@npm:0.1.1"
+"@hedgedoc/realtime@npm:0.2.0":
+  version: 0.2.0
+  resolution: "@hedgedoc/realtime@npm:0.2.0"
   dependencies:
     isomorphic-ws: ^5.0.0
     lib0: ^0.2.51
     typed-emitter: ^2.0.0
+    ws: ^8.0.0
     y-protocols: ^1.0.0
     yjs: ^13.0.0
-  checksum: 72e83af2d586b08daa13a56d6b2a00ff2fdff4196e9587241dc5bac80fd00fe59d88be6754631a0cc541e74d2059c63824e7c1675c7eaf0bb41ad6f6a0728f46
+  checksum: aae52554c3e37055680a090543e65d143cbcf0609e4cb762f2e60c5b6c8e88637a4b8c458ae26ab910f8e49b42177fd0c6c2e50268e392cbf6a396cbe3cd8769
   languageName: node
   linkType: hard
 
@@ -13816,7 +13817,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.8.1, ws@npm:^8.8.0":
+"ws@npm:8.8.1, ws@npm:^8.0.0, ws@npm:^8.8.0":
   version: 8.8.1
   resolution: "ws@npm:8.8.1"
   peerDependencies:


### PR DESCRIPTION
### Component/Part
realtime communication

### Description
When a user left a realtime-note, the awareness tried to send events even after the socket was closed, resulting in the app crashing.
This fix adds the check that the socket is still open before sending any messages.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
none
