### PR TITLE
Add build version to docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,3 +46,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            BUILD_VERSION=${{ github.event.head_commit.id }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,13 @@
 
 # BUILD
 FROM node:18-alpine AS builder
+ARG BUILD_VERSION=CLIENT_VERSION_MISSING
 ENV NEXT_TELEMETRY_DISABLED=1
 
 WORKDIR /app
 COPY . ./
 RUN yarn install --immutable && \
+    sed -i "s/CLIENT_VERSION_MISSING/${BUILD_VERSION}/" src/version.json && \
     yarn build:for-real-backend
 
 # RUNNER

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0",
+  "version": "CLIENT_VERSION_MISSING",
   "sourceCodeUrl": "https://github.com/hedgedoc/react-client",
   "issueTrackerUrl": "https://github.com/hedgedoc/react-client/issues"
 }


### PR DESCRIPTION
### Component/Part
Docker images

### Description
The current alpha deployment does not contain any information about the deployed version.
This PR adds a build argument to the Dockerfile to override the version string. For image built by the GitHub actions CI, it will be set to the commit that is used for the build.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
none
