### PR TITLE
Fix error when losing connection

### DIFF
--- a/src/components/editor-page/editor-pane/hooks/yjs/websocket-connection.ts
+++ b/src/components/editor-page/editor-pane/hooks/yjs/websocket-connection.ts
@@ -35,8 +35,8 @@ export class WebsocketConnection extends WebsocketTransporter {
       }
     }
     this.on('disconnected', () => {
-      awareness.destroy()
       awareness.off('update', updateCallback)
+      awareness.destroy()
     })
 
     this.on('ready', () => {


### PR DESCRIPTION
### Component/Part
Websocket connection

### Description
This PR fixes a error source by unbinding awareness events before destroying the awareness object.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
