### PR TITLE
chore(cypress): Update version of the cypress browsers image

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,7 +66,7 @@ jobs:
     needs: build-frontend
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node16.14.2-slim-chrome103-ff102
+      image: cypress/browsers:node18.6.0-chrome105-ff104
       options: --user 1001 --shm-size=2g
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Component/Part
e2e test workflow

### Description
This PR updates the version of the cypress browsers image in the e2e workflow.

### Steps

- [x] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
