### PR TITLE
refactor(code highlighter): Use sanitizer directly

### DIFF
--- a/src/components/markdown-renderer/markdown-extension/highlighted-fence/hooks/use-code-dom.tsx
+++ b/src/components/markdown-renderer/markdown-extension/highlighted-fence/hooks/use-code-dom.tsx
@@ -6,9 +6,9 @@
 
 import type { ReactElement } from 'react'
 import React, { Fragment, useMemo } from 'react'
-import { MarkdownExtensionCollection } from '../../markdown-extension-collection'
 import convertHtmlToReact from '@hedgedoc/html-to-react'
 import type { HLJSApi } from 'highlight.js'
+import { sanitize } from 'dompurify'
 
 /**
  * Highlights the given code using highlight.js. If the language wasn't recognized then it won't be highlighted.
@@ -32,8 +32,6 @@ export const useCodeDom = (code: string, hljs: HLJSApi | undefined, language?: s
   }, [code, hljs, language])
 }
 
-const nodeProcessor = new MarkdownExtensionCollection([]).buildFlatNodeProcessor()
-
 /**
  * Converts the given html code to react elements without any custom transformation but with sanitizing.
  *
@@ -41,13 +39,7 @@ const nodeProcessor = new MarkdownExtensionCollection([]).buildFlatNodeProcessor
  * @return the code represented as react elements
  */
 const createHtmlLinesToReactDOM = (code: string[]): ReactElement[] => {
-  return code.map((line, lineIndex) => (
-    <Fragment key={lineIndex}>
-      {convertHtmlToReact(line, {
-        preprocessNodes: nodeProcessor
-      })}
-    </Fragment>
-  ))
+  return code.map((line, lineIndex) => <Fragment key={lineIndex}>{convertHtmlToReact(sanitize(line))}</Fragment>)
 }
 
 /**


### PR DESCRIPTION
### Component/Part
Code highlighter

### Description
This PR improves the code highlighter by using dompurify directly instead of constructing a markdown extension collection.
Not only is it less confusing this way, it also simplifies the workflow by sanitizing the html from hljs directly instead of using the parsing-dumping-sanitizing-parsing workflow that happens when using the sanitizer node preprocessor.

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
