### PR TITLE
refactor(package.json): fix dev:for-real-backend npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "analyze": "cross-env ANALYZE=true next build",
     "dev": "cross-env PORT=3001 next dev",
     "dev:test": "cross-env PORT=3001 NODE_ENV=test NEXT_PUBLIC_TEST_MODE=true next dev",
-    "dev:for-real-backend": "cross-env PORT=3001 NEXT_PUBLIC_USE_MOCK_API=false NEXT_PUBLIC_BACKEND_BASE_URL=http://localhost:8080/ next dev",
+    "dev:for-real-backend": "cross-env PORT=3001 NEXT_PUBLIC_USE_MOCK_API=false HD_EDITOR_BASE_URL=http://localhost:8080/ next dev",
     "format": "prettier -c \"src/**/*.{ts,tsx,js}\" \"cypress/**/*.{ts,tsx}\"",
     "format:fix": "prettier -w \"src/**/*.{ts,tsx,js}\" \"cypress/**/*.{ts,tsx}\"",
     "lint": "eslint --max-warnings=0 --ext .ts,.tsx src",


### PR DESCRIPTION
### Component/Part
package.json

### Description
This PR fixes the dev:for-real-backend npm script. It now uses HD_EDITOR_BASE_URL instead of NEXT_PUBLIC_BACKEND_BASE_URL

### Steps

<!-- Please tick all steps this PR performs (if something is not necessary, please remove it) -->

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
