### PR TITLE
feat(window post message communicator): Use EventEmitter2

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "dompurify": "2.4.0",
     "emoji-picker-element": "1.12.1",
     "emoji-picker-element-data": "1.3.0",
+    "eventemitter2": "6.4.9",
     "fast-deep-equal": "3.1.3",
     "firacode": "6.2.0",
     "flowchart.js": "1.17.1",

--- a/src/components/render-page/window-post-message-communicator/hooks/use-editor-receive-handler.ts
+++ b/src/components/render-page/window-post-message-communicator/hooks/use-editor-receive-handler.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -7,7 +7,7 @@
 import { useEffect } from 'react'
 import type { CommunicationMessages, RendererToEditorMessageType } from '../rendering-message'
 import { useEditorToRendererCommunicator } from '../../../editor-page/render-context/editor-to-renderer-communicator-context-provider'
-import type { MaybeHandler } from '../window-post-message-communicator'
+import type { Handler } from '../window-post-message-communicator'
 
 /**
  * Sets the handler for the given message type in the current editor to renderer communicator.
@@ -17,13 +17,14 @@ import type { MaybeHandler } from '../window-post-message-communicator'
  */
 export const useEditorReceiveHandler = <R extends RendererToEditorMessageType>(
   messageType: R,
-  handler: MaybeHandler<CommunicationMessages, R>
+  handler?: Handler<CommunicationMessages, R>
 ): void => {
   const editorToRendererCommunicator = useEditorToRendererCommunicator()
   useEffect(() => {
-    editorToRendererCommunicator.setHandler(messageType, handler)
-    return () => {
-      editorToRendererCommunicator.setHandler(messageType, undefined)
+    if (!handler) {
+      return
     }
+    editorToRendererCommunicator.on(messageType, handler)
+    return () => editorToRendererCommunicator.off(messageType, handler)
   }, [editorToRendererCommunicator, handler, messageType])
 }

--- a/src/components/render-page/window-post-message-communicator/hooks/use-renderer-receive-handler.ts
+++ b/src/components/render-page/window-post-message-communicator/hooks/use-renderer-receive-handler.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -26,9 +26,7 @@ export const useRendererReceiveHandler = <MESSAGE_TYPE extends EditorToRendererM
 ): void => {
   const editorToRendererCommunicator = useRendererToEditorCommunicator()
   useEffect(() => {
-    editorToRendererCommunicator.setHandler(messageType, handler)
-    return () => {
-      editorToRendererCommunicator.setHandler(messageType, undefined)
-    }
+    editorToRendererCommunicator.on(messageType, handler)
+    return () => editorToRendererCommunicator.off(messageType, handler)
   }, [editorToRendererCommunicator, handler, messageType])
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1987,6 +1987,7 @@ __metadata:
     eslint-plugin-prettier: 4.2.1
     eslint-plugin-promise: 6.0.1
     eslint-plugin-testing-library: 5.7.0
+    eventemitter2: 6.4.9
     fast-deep-equal: 3.1.3
     firacode: 6.2.0
     flowchart.js: 1.17.1
@@ -7006,6 +7007,13 @@ __metadata:
   version: 6.4.7
   resolution: "eventemitter2@npm:6.4.7"
   checksum: 1b36a77e139d6965ebf3a36c01fa00c089ae6b80faa1911e52888f40b3a7057b36a2cc45dcd1ad87cda3798fe7b97a0aabcbb8175a8b96092a23bb7d0f039e66
+  languageName: node
+  linkType: hard
+
+"eventemitter2@npm:6.4.9":
+  version: 6.4.9
+  resolution: "eventemitter2@npm:6.4.9"
+  checksum: be59577c1e1c35509c7ba0e2624335c35bbcfd9485b8a977384c6cc6759341ea1a98d3cb9dbaa5cea4fff9b687e504504e3f9c2cc1674cf3bd8a43a7c74ea3eb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Component/Part
Window post message communicator

### Description
This PR replaces the custom single-handler architecture with eventemitter2.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
