### PR TITLE
feat(window post message communicator): Add uuid to frames

### DIFF
--- a/src/components/editor-page/render-context/editor-to-renderer-communicator-context-provider.tsx
+++ b/src/components/editor-page/render-context/editor-to-renderer-communicator-context-provider.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 The HedgeDoc developers (see AUTHORS file)
+ * SPDX-FileCopyrightText: 2022 The HedgeDoc developers (see AUTHORS file)
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -7,6 +7,7 @@
 import type { PropsWithChildren } from 'react'
 import React, { createContext, useContext, useEffect, useMemo } from 'react'
 import { EditorToRendererCommunicator } from '../../render-page/window-post-message-communicator/editor-to-renderer-communicator'
+import { v4 as uuid } from 'uuid'
 
 const EditorToRendererCommunicatorContext = createContext<EditorToRendererCommunicator | undefined>(undefined)
 
@@ -27,8 +28,8 @@ export const useEditorToRendererCommunicator: () => EditorToRendererCommunicator
 /**
  * Provides a {@link EditorToRendererCommunicator editor to renderer communicator} for the child components via Context.
  */
-export const EditorToRendererCommunicatorContextProvider: React.FC<PropsWithChildren<unknown>> = ({ children }) => {
-  const communicator = useMemo<EditorToRendererCommunicator>(() => new EditorToRendererCommunicator(), [])
+export const EditorToRendererCommunicatorContextProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const communicator = useMemo<EditorToRendererCommunicator>(() => new EditorToRendererCommunicator(uuid()), [])
 
   useEffect(() => {
     const currentCommunicator = communicator

--- a/src/components/editor-page/render-context/renderer-to-editor-communicator-context-provider.tsx
+++ b/src/components/editor-page/render-context/renderer-to-editor-communicator-context-provider.tsx
@@ -9,6 +9,7 @@ import React, { createContext, useContext, useEffect, useMemo } from 'react'
 import { RendererToEditorCommunicator } from '../../render-page/window-post-message-communicator/renderer-to-editor-communicator'
 import { CommunicationMessageType } from '../../render-page/window-post-message-communicator/rendering-message'
 import { ORIGIN, useBaseUrl } from '../../../hooks/common/use-base-url'
+import { useSingleStringUrlParameter } from '../../../hooks/common/use-single-string-url-parameter'
 
 const RendererToEditorCommunicatorContext = createContext<RendererToEditorCommunicator | undefined>(undefined)
 
@@ -28,7 +29,14 @@ export const useRendererToEditorCommunicator: () => RendererToEditorCommunicator
 
 export const RendererToEditorCommunicatorContextProvider: React.FC<PropsWithChildren<unknown>> = ({ children }) => {
   const editorOrigin = useBaseUrl(ORIGIN.EDITOR)
-  const communicator = useMemo<RendererToEditorCommunicator>(() => new RendererToEditorCommunicator(), [])
+  const uuid = useSingleStringUrlParameter('uuid', undefined)
+  const communicator = useMemo<RendererToEditorCommunicator>(() => {
+    if (uuid === undefined) {
+      throw new Error('no uuid found in url!')
+    } else {
+      return new RendererToEditorCommunicator(uuid)
+    }
+  }, [uuid])
 
   useEffect(() => {
     const currentCommunicator = communicator

--- a/src/components/editor-page/renderer-pane/hooks/use-force-render-page-url-on-iframe-load-callback.ts
+++ b/src/components/editor-page/renderer-pane/hooks/use-force-render-page-url-on-iframe-load-callback.ts
@@ -8,6 +8,7 @@ import type { RefObject } from 'react'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { Logger } from '../../../../utils/logger'
 import { ORIGIN, useBaseUrl } from '../../../../hooks/common/use-base-url'
+import { useEditorToRendererCommunicator } from '../../render-context/editor-to-renderer-communicator-context-provider'
 
 const log = new Logger('IframeLoader')
 
@@ -19,14 +20,16 @@ const log = new Logger('IframeLoader')
  */
 export const useForceRenderPageUrlOnIframeLoadCallback = (
   iFrameReference: RefObject<HTMLIFrameElement>,
-  onNavigateAway?: () => void
+  onNavigateAway: () => void
 ): (() => void) => {
+  const iframeCommunicator = useEditorToRendererCommunicator()
   const rendererBaseUrl = useBaseUrl(ORIGIN.RENDERER)
   const forcedUrl = useMemo(() => {
     const renderUrl = new URL(rendererBaseUrl)
     renderUrl.pathname += 'render'
+    renderUrl.searchParams.set('uuid', iframeCommunicator.getUuid())
     return renderUrl.toString()
-  }, [rendererBaseUrl])
+  }, [iframeCommunicator, rendererBaseUrl])
   const redirectionInProgress = useRef<boolean>(false)
 
   const loadCallback = useCallback(() => {


### PR DESCRIPTION
### Component/Part
Window post message communicator

### Description
This PR adds uuids to identify and separate multiple renderers on one page

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
