### PR TITLE
chores(deps): Add resolution for @hpcc-js/wasm

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
   "resolutions": {
     "domhandler": "5.0.3",
     "@codemirror/state": "6.1.2",
-    "@codemirror/view": "6.3.1"
+    "@codemirror/view": "6.3.1",
+    "@hpcc-js/wasm": "1.16.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2067,17 +2067,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hpcc-js/wasm@npm:1.16.1":
-  version: 1.16.1
-  resolution: "@hpcc-js/wasm@npm:1.16.1"
-  dependencies:
-    yargs: 17.5.1
-  bin:
-    dot-wasm: bin/cli.js
-  checksum: b70bc1fece40e8f6c81011534b5b9bbde9123bac453d13c9642b112565f7dd85b1fb7656bec06447c78295f7c893afd1cd08dc17945d6b8f9319ba2e289f4597
-  languageName: node
-  linkType: hard
-
 "@hpcc-js/wasm@npm:1.16.5":
   version: 1.16.5
   resolution: "@hpcc-js/wasm@npm:1.16.5"


### PR DESCRIPTION
### Component/Part
package.json

### Description
Adds a resolution to prevent multiple versions of the graphviz wasm lib.

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
