### PR TITLE
fix(sidebar): Remove pdf export entry

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -378,7 +378,6 @@
     },
     "export": {
       "rawHtml": "Raw HTML",
-      "pdf": "PDF export is unavailable.",
       "markdown-file": "Markdown file"
     },
     "import": {

--- a/src/components/editor-page/sidebar/specific-sidebar-entries/export-menu-sidebar-menu.tsx
+++ b/src/components/editor-page/sidebar/specific-sidebar-entries/export-menu-sidebar-menu.tsx
@@ -6,7 +6,6 @@
 
 import React, { Fragment, useCallback } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import links from '../../../../links.json'
 import { ExportMarkdownSidebarEntry } from './export-markdown-sidebar-entry'
 import { SidebarButton } from '../sidebar-button/sidebar-button'
 import { SidebarMenu } from '../sidebar-menu/sidebar-menu'
@@ -55,15 +54,6 @@ export const ExportMenuSidebarMenu: React.FC<SpecificSidebarMenuProps> = ({
         <SidebarButton icon={'file-code-o'}>HTML</SidebarButton>
         <SidebarButton icon={'file-code-o'}>
           <Trans i18nKey='editor.export.rawHtml' />
-        </SidebarButton>
-        <SidebarButton icon={'file-pdf-o'}>
-          <a className='small text-muted' dir={'auto'} href={links.faq} target={'_blank'} rel='noopener noreferrer'>
-            <Trans i18nKey={'editor.export.pdf'} />
-            &nbsp;
-            <span className={'text-primary'}>
-              <Trans i18nKey={'common.why'} />
-            </span>
-          </a>
         </SidebarButton>
       </SidebarMenu>
     </Fragment>

--- a/src/links.json
+++ b/src/links.json
@@ -1,7 +1,6 @@
 {
   "chat": "https://matrix.to/#/#hedgedoc:matrix.org",
   "community": "https://community.hedgedoc.org",
-  "faq": "https://hedgedoc.org/faq/",
   "githubOrg": "https://github.com/hedgedoc/",
   "backendSourceCode": "https://github.com/hedgedoc/hedgedoc",
   "backendIssues": "https://github.com/hedgedoc/hedgedoc/issues",


### PR DESCRIPTION
### Component/Part
sidebar

### Description
This PR removes the pdf export sidebar entry.
The URL that is used in this entry doesn't exist anymore. We don't plan to implement pdf export with 2.0 anyway so this entry isn't needed.

### Steps
- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
