### PR TITLE
Remove "display: none" from cm-bufferWidget style

### DIFF
--- a/src/components/editor-page/editor-pane/extended-codemirror/codemirror.module.scss
+++ b/src/components/editor-page/editor-pane/extended-codemirror/codemirror.module.scss
@@ -18,7 +18,7 @@
 
   :global {
     .cm-widgetBuffer {
-      display: none;
+      position: absolute;
     }
 
     .cm-diagnostic {


### PR DESCRIPTION
### Component/Part
markdown editor
extended-codemirror

### Description
This PR fixes hedgedoc/hedgedoc#2957 (remote cursor on empty line will blast away local cursor when pressing down-arrow from the same position)

CodeMirror-view doesn't allow cm-widgetBuffer to be "display: none", which results in a useless rect {0,0,0,0,...} and coords (0,0).

Imagine you are editing a note with thousands of lines.
Your cursor is at the line 10,000
and a remote cursor is at the line 10,001,
which is an empty line.
You press down-arrow key.
Your cursor will be at the same position
of the remote cursor. Great.
Then you press down-arrow key again.
This time, you'll be at the line 1! How annoying!

Simply deleting the "display: none" will reintroduce
https://github.com/yjs/y-codemirror.next/pull/12
so I replaced it with "position: absolute".
Seems like it works for me.

### Steps
- [x] Added implementation
- [ ] Added / updated tests
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Related Issue(s)
hedgedoc/hedgedoc#2957
https://github.com/yjs/y-codemirror.next/pull/12 (prevent linebreaks)
https://github.com/codemirror/view/pull/42 (keep "display: inline")

