### PR TITLE
fix(ci): fix regex manager name for node version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -110,7 +110,8 @@
       "matchStrings": [
         "NODE_VERSION=(?<currentValue>.*?)\\n"
       ],
-      "datasourceTemplate" : "node"
+      "datasourceTemplate" : "node",
+      "depNameTemplate" : "node version in workflows"
     }
   ]
 }


### PR DESCRIPTION
### Component/Part
renovate

### Description
This PR fixes the name of the node version regex manager

### Steps

- [x] Added implementation
- [x] I read the [contribution documentation](https://github.com/hedgedoc/react-client/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
